### PR TITLE
docs: update x402 foundation references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ Filter semantically via the query text, not parameters:
 ### Fixed
 - **PAYMENT-RESPONSE header** — Server middleware now sets `PAYMENT-RESPONSE` header (base64-encoded settlement data) on 200 OK responses after successful payment, per the x402 v2 HTTP transport spec. Previously, settlement data was only attached to `req.x402` but not surfaced as a response header.
 - **`amount` field in 402 response** — The `accepts` array in payment requirements now includes both `amount` (v2 spec field) and `maxAmountRequired` (legacy field). Non-Dexter v2 clients that look for `amount` instead of `maxAmountRequired` will now find it.
-- **`x402Version` in facilitator requests** — The `FacilitatorClient` now sends `x402Version: 2` at the top level of `/verify` and `/settle` request bodies, matching the Coinbase reference implementation format.
+- **`x402Version` in facilitator requests** — The `FacilitatorClient` now sends `x402Version: 2` at the top level of `/verify` and `/settle` request bodies, matching the x402 Foundation reference implementation format.
 
 ### Added
 - `test/v2-spec-compliance.ts` — Automated test suite validating all three v2 spec compliance fixes against a mock facilitator (6 assertions).

--- a/docs/superpowers/plans/2026-05-18-x402-version-seam-plan-1-paying-side.md
+++ b/docs/superpowers/plans/2026-05-18-x402-version-seam-plan-1-paying-side.md
@@ -846,7 +846,7 @@ writing this task's implementation, the engineer MUST read the upstream
 `x402` library's v1 payment code (`node_modules/x402/dist/cjs/` in
 `dexter-api` — functions `createPaymentHeader`, `preparePaymentHeader`,
 `signPaymentHeader`) and the v1 spec at
-`github.com/coinbase/x402/blob/main/specs/x402-specification-v1.md`.
+`github.com/x402-foundation/x402/blob/main/specs/x402-specification-v1.md`.
 The goal is to understand how v1 builds and signs the `X-PAYMENT`
 header (EIP-3009 `transferWithAuthorization` for EVM; the SVM
 equivalent), then reimplement it inside this module.

--- a/src/server/x402-server.ts
+++ b/src/server/x402-server.ts
@@ -235,7 +235,7 @@ export function createX402Server(config: X402ServerConfig): X402Server {
   // Requirements cache: payTo address -> PaymentAccept + expiry.
   // Populated by buildRequirements/getPaymentAccept, consumed by verify/settle.
   // Prevents the bug where verify/settle fabricates requirements with amount '0'.
-  // Parallels the SettlementCache pattern from coinbase/x402.
+  // Parallels the SettlementCache pattern from x402-foundation/x402.
   const requirementsCache = new Map<string, { accept: PaymentAccept; expiresAt: number }>();
   const CACHE_PRUNE_INTERVAL = 30_000;
   let lastPrune = Date.now();


### PR DESCRIPTION
## Summary

- update the old `github.com/coinbase/x402` v1 spec reference to `github.com/x402-foundation/x402`
- replace remaining Coinbase-specific wording/comments with x402 Foundation wording
- verify there are no remaining `coinbase` references in the repo

Fixes #41.

## Verification

- `git grep -n -i "coinbase"` returns no matches
- `git diff --check`
- confirmed `x402-foundation/x402/specs/x402-specification-v1.md` exists via GitHub API

No build/test run: documentation/comment-only change.
