### PR TITLE
fix(tab): send exact terminal reservation amount

### DIFF
--- a/src/tab/__tests__/from-grant.test.ts
+++ b/src/tab/__tests__/from-grant.test.ts
@@ -745,6 +745,7 @@ describe('tabFromGrant — settle-only close', () => {
     const settle = calls.find((c) => c.url === `${FAC}/tab/settle`);
     expect(settle).toBeDefined();
     expect(settle!.body).toMatchObject({
+      attemptedAmount: '5000',
       channelId: v.payload.channelId,
       cumulativeAmount: '255000',
       sequenceNumber: 0x8000_0001,
@@ -758,6 +759,43 @@ describe('tabFromGrant — settle-only close', () => {
     expect(result.settleTx).toBe('SETTLE_TX');
     expect(result.sessionRevoked).toBe(false); // honest: NO on-chain revoke happened
     await expect(tab.signNextVoucher('5000')).rejects.toThrow(/closed/i);
+  });
+
+  it('close() sends the final V2 voucher reservation increment, not the cumulative local span', async () => {
+    const { calls } = stubFetchRouter();
+    const kp = nacl.sign.keyPair();
+    const params = grantParams(kp);
+    const conn = connFor(params, sessionAccountData({ params, spent: 250000n }));
+    const reserved: Array<import('../types').FinalVoucherV2ReservationInput> = [];
+
+    const tab = await tabFromGrant({
+      ...baseOptions(kp, params, conn),
+      reserveFinalVoucherV2: async input => {
+        // A real second reservation only succeeds after the first reservation
+        // has terminaled and cleared current_outstanding. This unit callback
+        // represents that accepted sequential lifecycle.
+        reserved.push(input);
+        return finalizedReservationReceipt(input);
+      },
+    });
+    await tab.signNextVoucher('5000');
+    const finalVoucher = await tab.signNextVoucher('4000');
+    await tab.close();
+
+    expect(reserved.map(input => ({
+      amount: input.reservationAmountAtomic,
+      previous: input.previousCumulativeAtomic,
+      cumulative: input.voucher.payload.cumulativeAmount,
+    }))).toEqual([
+      { amount: '5000', previous: '250000', cumulative: '255000' },
+      { amount: '4000', previous: '255000', cumulative: '259000' },
+    ]);
+    const settle = calls.find((c) => c.url === `${FAC}/tab/settle`);
+    expect(settle!.body).toMatchObject({
+      attemptedAmount: '4000',
+      cumulativeAmount: '259000',
+      sequenceNumber: finalVoucher.payload.sequenceNumber,
+    });
   });
 
   it('close() with zero vouchers signed settles nothing and still closes', async () => {

--- a/src/tab/__tests__/settle-fee.test.ts
+++ b/src/tab/__tests__/settle-fee.test.ts
@@ -57,7 +57,10 @@ function jsonResponse(body: unknown, status = 200): Response {
  * already-issued historical tab; v6 public open/recovery does not arm V1.
  */
 function makeRoutingFetch(settleResponse: () => Response) {
-  return vi.fn(async (_input: string | URL | Request) => settleResponse());
+  return vi.fn(async (
+    _input: string | URL | Request,
+    _init?: RequestInit,
+  ) => settleResponse());
 }
 
 /** Build an already-issued V1 tab and sign one voucher for close coverage. */
@@ -121,6 +124,10 @@ describe('Tab.close() — facilitator fee fields', () => {
     );
     expect(settleCalls).toHaveLength(1);
     expect(String(settleCalls[0]![0])).toBe(`${FACILITATOR_URL}/tab/settle`);
+    expect(JSON.parse(String(settleCalls[0]![1]?.body))).toMatchObject({
+      attemptedAmount: '10000',
+      cumulativeAmount: '10000',
+    });
   });
 
   it('leaves the fee fields undefined when an old facilitator omits them', async () => {
@@ -139,6 +146,51 @@ describe('Tab.close() — facilitator fee fields', () => {
     expect(result.grossAmount).toBeUndefined();
     expect(result.feeAmount).toBeUndefined();
     expect(result.netAmount).toBeUndefined();
+  });
+
+  it('settles the full cumulative span of a grandfathered multi-voucher V1 tab', async () => {
+    const mockFetch = makeRoutingFetch(() =>
+      jsonResponse({
+        settleTx: 'sig',
+        cumulativeAmount: '8000',
+        transferAmount: '8000',
+      }),
+    );
+    vi.stubGlobal('fetch', mockFetch);
+    const vault = makeFakeAdapter();
+    const expiresAtUnix = Math.floor(Date.now() / 1000) + 3600;
+    const channelIdHex = '22'.repeat(32);
+    const session = await vault.authorizeSession({
+      channelId: channelIdHex,
+      maxAmountAtomic: '5000000',
+      revolvingCapacityAtomic: '5000000',
+      expiresAtUnix,
+      allowedCounterparty: SELLER_PUBKEY,
+    });
+    const tab = new TabImpl({
+      vault,
+      network: 'solana:mainnet',
+      seller: SELLER_PUBKEY,
+      counterparty: SELLER_PUBKEY,
+      session,
+      channelIdHex,
+      channelIdBytes: Uint8Array.from(Buffer.from(channelIdHex, 'hex')),
+      perUnitCapAtomic: 10000n,
+      totalCapAtomic: 5000000n,
+      expiresAtUnix,
+      facilitatorUrl: FACILITATOR_URL,
+    });
+    await tab.signNextVoucher('3000');
+    await tab.signNextVoucher('5000');
+    await tab.close();
+
+    const settleCall = mockFetch.mock.calls.find(([url]) =>
+      String(url).endsWith('/tab/settle'),
+    );
+    expect(JSON.parse(String(settleCall?.[1]?.body))).toMatchObject({
+      attemptedAmount: '8000',
+      cumulativeAmount: '8000',
+    });
   });
 
   it('ignores non-string fee field values rather than coercing them', async () => {

--- a/src/tab/__tests__/voucher-accounting.test.ts
+++ b/src/tab/__tests__/voucher-accounting.test.ts
@@ -444,6 +444,28 @@ describe('Tab.rollbackVoucher — internal honest-refusal rollback', () => {
     expect(reissued.payload.cumulativeAmount).toBe(second.payload.cumulativeAmount);
   });
 
+  it('restores the previous voucher attempted amount together with the voucher', async () => {
+    const tab = await makeTab(makeFakeAdapter());
+    const first = await tab.signNextVoucher('3000');
+    const second = await tab.signNextVoucher('5000');
+    expect(tab.rollbackVoucher(second)).toBe(true);
+
+    let settleBody: any;
+    vi.stubGlobal('fetch', vi.fn(async (_url, init?: RequestInit) => {
+      settleBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ settleTx: 'SETTLE_TX' }), {
+        status: 200,
+      });
+    }));
+    await tab.close();
+
+    expect(tab.lastSignedVoucher).toBe(first);
+    expect(settleBody).toMatchObject({
+      attemptedAmount: '3000',
+      cumulativeAmount: '3000',
+    });
+  });
+
   it('rolls a first-and-only voucher back to the pristine state', async () => {
     const tab = await makeTab(makeFakeAdapter());
 

--- a/src/tab/tab.ts
+++ b/src/tab/tab.ts
@@ -168,11 +168,17 @@ class TabImpl implements Tab {
    *  it back to us. Null if no voucher was signed in this tab's lifetime
    *  (close-without-stream → nothing to settle). */
   private lastSignedVoucher: SignedVoucher | null = null;
+  /** Exact economic increment bound to `lastSignedVoucher`. In Native Tab V2
+   *  this is also the immutable reservation amount, and `/tab/settle` must
+   *  send this value rather than reconstructing it from lifetime cumulative. */
+  private lastSignedVoucherIncrementAtomic: bigint | null = null;
   /** One level of voucher history: the voucher that was `lastSignedVoucher`
    *  immediately before the current one. Retained so `rollbackVoucher` can
    *  restore the pre-refusal voucher when a seller honestly refuses the
    *  most recent one. Set at commit time inside `signNextVoucher`. */
   private previousSignedVoucher: SignedVoucher | null = null;
+  /** Increment paired with `previousSignedVoucher`, retained for V1 rollback. */
+  private previousSignedVoucherIncrementAtomic: bigint | null = null;
 
   constructor(internals: TabInternals) {
     this.internals = internals;
@@ -292,7 +298,10 @@ class TabImpl implements Tab {
 
     // Commit: counters, one level of history, and the new last voucher.
     this.previousSignedVoucher = this.lastSignedVoucher;
+    this.previousSignedVoucherIncrementAtomic =
+      this.lastSignedVoucherIncrementAtomic;
     this.lastSignedVoucher = signed;
+    this.lastSignedVoucherIncrementAtomic = incBig;
     this.sequenceNumber = nextSequence;
     this.cumulativeAtomic = newCumulative;
     return signed;
@@ -371,9 +380,12 @@ class TabImpl implements Tab {
 
     const prev = this.previousSignedVoucher;
     if (prev) {
+      const prevIncrement = this.previousSignedVoucherIncrementAtomic;
+      if (prevIncrement === null) return false;
       this.sequenceNumber = prev.payload.sequenceNumber;
       this.cumulativeAtomic = BigInt(prev.payload.cumulativeAmount);
       this.lastSignedVoucher = prev;
+      this.lastSignedVoucherIncrementAtomic = prevIncrement;
     } else if (last.payload.sequenceNumber === 1) {
       // The refused voucher was the tab's first — revert to the pristine
       // state: the odometer FLOOR this tab was constructed at (0n for
@@ -381,11 +393,13 @@ class TabImpl implements Tab {
       this.sequenceNumber = 0;
       this.cumulativeAtomic = this.initialCumulativeAtomic;
       this.lastSignedVoucher = null;
+      this.lastSignedVoucherIncrementAtomic = null;
     } else {
       // History exhausted (only one level retained) — refuse rather than guess.
       return false;
     }
     this.previousSignedVoucher = null;
+    this.previousSignedVoucherIncrementAtomic = null;
     return true;
   }
 
@@ -460,10 +474,21 @@ class TabImpl implements Tab {
 
       let settled: SettleResult = { settleTx: '' };
       if (this.lastSignedVoucher && this.cumulativeAtomic > 0n) {
+        // Native Tab V2 reserves one exact obligation at a time, so close
+        // declares the FINAL voucher's immutable reservation increment.
+        // Grandfathered V1 tabs instead accumulate several vouchers before
+        // one terminal settle and therefore declare the complete local span.
+        const attemptedAmount = this.isFinalV2
+          ? this.lastSignedVoucherIncrementAtomic
+          : this.cumulativeAtomic - this.initialCumulativeAtomic;
+        if (attemptedAmount === null || attemptedAmount <= 0n) {
+          throw new Error('tab_settle_attempted_amount_missing');
+        }
         settled = await postSettle(
           this.internals.facilitatorUrl,
           this.lastSignedVoucher,
           this.internals.network,
+          attemptedAmount.toString(),
         );
       }
 
@@ -605,9 +630,11 @@ async function postSettle(
   facilitatorUrl: string,
   voucher: SignedVoucher,
   network: TabNetworkId,
+  attemptedAmount: AtomicAmount,
 ): Promise<SettleResult> {
   const url = `${facilitatorUrl.replace(/\/$/, '')}/tab/settle`;
   const body = {
+    attemptedAmount,
     channelId: voucher.payload.channelId,
     cumulativeAmount: voucher.payload.cumulativeAmount,
     sequenceNumber: voucher.payload.sequenceNumber,


### PR DESCRIPTION
## Summary
- retain the exact increment bound to each V2 FINAL reservation
- send that reservation amount as attemptedAmount during close/settle
- preserve V1 cumulative-from-initial terminal semantics
- preserve exact amount history across voucher rollback

## Verification
- full SDK suite: 66 files, 566/566 tests passed
- focused terminal/accounting suite: 51/51 passed
- typecheck and ESM/CJS/DTS build passed
- git diff --check passed

This fixes the buyer-side omission exposed by the first mainnet V2 canary. No claim was reissued or settled while preparing this change.