### PR TITLE
fix(tab): verify exact seller reservations

### DIFF
--- a/src/payment/__tests__/tab-negotiation.test.ts
+++ b/src/payment/__tests__/tab-negotiation.test.ts
@@ -519,6 +519,19 @@ describe('v2Strategy.pay — tab negotiation', () => {
     );
     expect(refused.payload.sequenceNumber).toBe(0x8000_0002);
     expect(refused.payload.cumulativeAmount).toBe('10000');
+    expect(refused.reservationReceipt).toMatchObject({
+      contract: 'dexter-native-tab-open-receipt/v1',
+      transaction: '5'.repeat(88),
+      commitment: 'finalized',
+      seller: SELLER_PUBKEY,
+      channelId: refused.payload.channelId,
+      sessionPublicKey: refused.sessionPublicKey,
+      cumulativeAmountAtomic: '10000',
+      sequenceNumber: 0x8000_0002,
+      reservationAmountAtomic: '5000',
+      currentOutstandingAfterAtomic: '5000',
+    });
+    expect(refused.reservationReceipt.voucherDigest).toMatch(/^[0-9a-f]{64}$/);
     expect(tab.lastSignedVoucher?.payload).toEqual(refused.payload);
     expect(tab.state.spent).toBe('0.01');
   });

--- a/src/tab/__tests__/from-grant.test.ts
+++ b/src/tab/__tests__/from-grant.test.ts
@@ -109,11 +109,19 @@ function sessionPdaFor(params: ApprovedSpendGrantParams): PublicKey {
   return deriveSessionPda(VAULT, new PublicKey(params.counterparty))[0];
 }
 
-/** Minimal Connection double: serves getAccountInfo from a base58→Buffer map. */
-function fakeConnection(accounts: Map<string, Buffer>): Connection & { reads: string[] } {
+type MutableConnection = Connection & {
+  reads: string[];
+  setAccount: (address: PublicKey, data: Buffer) => void;
+};
+
+/** Minimal mutable Connection double: serves getAccountInfo from a base58→Buffer map. */
+function fakeConnection(accounts: Map<string, Buffer>): MutableConnection {
   const reads: string[] = [];
   return {
     reads,
+    setAccount: (address: PublicKey, data: Buffer) => {
+      accounts.set(address.toBase58(), data);
+    },
     getAccountInfo: async (pda: PublicKey) => {
       reads.push(pda.toBase58());
       const data = accounts.get(pda.toBase58());
@@ -127,7 +135,7 @@ function fakeConnection(accounts: Map<string, Buffer>): Connection & { reads: st
           }
         : null;
     },
-  } as unknown as Connection & { reads: string[] };
+  } as unknown as MutableConnection;
 }
 
 function connFor(params: ApprovedSpendGrantParams, data?: Buffer, extra?: Array<[string, Buffer]>) {
@@ -241,8 +249,11 @@ describe('tabFromGrant — registration rebuild', () => {
       sessionNonce: 0x8000_0000 + 42,
       reservationAmountAtomic: '5000',
       previousCumulativeAtomic: '0',
-      voucher,
+      voucher: expect.objectContaining({ payload: voucher.payload }),
     }));
+    expect(voucher.reservationReceipt).toEqual(
+      finalizedReservationReceipt(reserveFinalVoucherV2.mock.calls[0][0]),
+    );
     expect(calls.some((call) => call.url === `${FAC}/tab/open`)).toBe(false);
   });
 
@@ -285,10 +296,17 @@ describe('tabFromGrant — registration rebuild', () => {
     const voucher = await tab.signNextVoucher('5000');
     expect(voucher.payload.sequenceNumber).toBe(0x8000_0001);
     expect(reserved).toHaveLength(2);
-    expect(voucherToHeader(reserved[1].voucher)).toBe(
-      voucherToHeader(reserved[0].voucher),
+    expect(reserved[1].voucher).toEqual(reserved[0].voucher);
+    expect(voucher).toMatchObject(reserved[0].voucher);
+    expect(voucher.reservationReceipt).toEqual(
+      finalizedReservationReceipt(reserved[1]),
     );
-    expect(voucherToHeader(voucher)).toBe(voucherToHeader(reserved[0].voucher));
+    const decodedHeader = JSON.parse(
+      Buffer.from(voucherToHeader(voucher), 'base64').toString('utf8'),
+    );
+    expect(decodedHeader.reservationReceipt).toEqual(
+      voucher.reservationReceipt,
+    );
     expect((tab as any).rollbackVoucher(voucher)).toBe(false);
   });
 
@@ -556,7 +574,13 @@ describe('tabFromGrant — voucher satisfies the seller middleware (real oracle)
     const conn = connFor(params, sessionAccountData({ params }));
     const tab = await tabFromGrant({
       ...baseOptions(kp, params, conn),
-      reserveFinalVoucherV2: async (input) => finalizedReservationReceipt(input),
+      reserveFinalVoucherV2: async (input) => {
+        conn.setAccount(
+          sessionPdaFor(params),
+          sessionAccountData({ params, currentOutstanding: 5000n }),
+        );
+        return finalizedReservationReceipt(input);
+      },
     });
     const mw = tabMiddleware({
       connection: conn,
@@ -589,7 +613,24 @@ describe('tabFromGrant — voucher satisfies the seller middleware (real oracle)
     const accountData = sessionAccountData({ params, spent: 250000n, crystallized: 100000n });
     const conn = connFor(params, accountData);
 
-    const tab = await tabFromGrant(baseOptions(kp, params, conn));
+    const tab = await tabFromGrant({
+      ...baseOptions(kp, params, conn),
+      reserveFinalVoucherV2: async (input) => {
+        const settledFrontier = input.previousCumulativeAtomic === '250000'
+          ? 250000n
+          : 255000n;
+        conn.setAccount(
+          sessionPdaFor(params),
+          sessionAccountData({
+            params,
+            spent: settledFrontier,
+            crystallized: 100000n,
+            currentOutstanding: 5000n,
+          }),
+        );
+        return finalizedReservationReceipt(input);
+      },
+    });
 
     // One middleware instance across both requests: session cache + ledger persist.
     const mw = tabMiddleware({
@@ -617,6 +658,18 @@ describe('tabFromGrant — voucher satisfies the seller middleware (real oracle)
     res1.emit('close');
     await new Promise((r) => setTimeout(r, 0));
 
+    // The first FINAL obligation settles before the next exact reservation.
+    conn.setAccount(
+      sessionPdaFor(params),
+      sessionAccountData({
+        params,
+        spent: 255000n,
+        crystallized: 100000n,
+        currentOutstanding: 0n,
+        lastLockedSequence: 0x8000_0001,
+      }),
+    );
+
     // Request 2 — monotonicity against the seller's cached cumulative.
     const v2 = await tab.signNextVoucher('5000');
     const req2 = fakeReq(voucherToHeader(v2));
@@ -628,13 +681,22 @@ describe('tabFromGrant — voucher satisfies the seller middleware (real oracle)
     expect(req2.tab!.cumulative()).toBe('0.26');
   });
 
-  it('a REPLAYED voucher is rejected by the seller as non-monotonic', async () => {
+  it('a REPLAYED V2 voucher is rejected by the seller as already covered', async () => {
     stubFetchRouter();
     const kp = nacl.sign.keyPair();
     const params = grantParams(kp);
     const conn = connFor(params, sessionAccountData({ params }));
 
-    const tab = await tabFromGrant(baseOptions(kp, params, conn));
+    const tab = await tabFromGrant({
+      ...baseOptions(kp, params, conn),
+      reserveFinalVoucherV2: async (input) => {
+        conn.setAccount(
+          sessionPdaFor(params),
+          sessionAccountData({ params, currentOutstanding: 5000n }),
+        );
+        return finalizedReservationReceipt(input);
+      },
+    });
     const mw = tabMiddleware({
       connection: conn,
       sellerPubkey: SELLER.toBase58(),
@@ -653,11 +715,14 @@ describe('tabFromGrant — voucher satisfies the seller middleware (real oracle)
     res1.emit('finish');
     await new Promise((r) => setTimeout(r, 0));
 
-    // Same voucher again — cumulative not strictly greater → 402 non_monotonic.
+    // Same voucher again — it is already covered by the seller ledger.
     const res2 = fakeRes();
     await mw(fakeReq(header) as unknown as ExpressRequest, res2 as unknown as ExpressResponse, vi.fn() as NextFunction);
     expect(res2.statusCode).toBe(402);
-    expect(res2.body).toMatchObject({ error: 'invalid_voucher', reason: 'non_monotonic' });
+    expect(res2.body).toMatchObject({
+      error: 'invalid_voucher',
+      reason: 'voucher_already_covered',
+    });
   });
 
   it('never lets a forged registration/key inherit a verified channel cache entry', async () => {
@@ -665,7 +730,16 @@ describe('tabFromGrant — voucher satisfies the seller middleware (real oracle)
     const kp = nacl.sign.keyPair();
     const params = grantParams(kp);
     const conn = connFor(params, sessionAccountData({ params }));
-    const tab = await tabFromGrant(baseOptions(kp, params, conn));
+    const tab = await tabFromGrant({
+      ...baseOptions(kp, params, conn),
+      reserveFinalVoucherV2: async (input) => {
+        conn.setAccount(
+          sessionPdaFor(params),
+          sessionAccountData({ params, currentOutstanding: 5000n }),
+        );
+        return finalizedReservationReceipt(input);
+      },
+    });
     const mw = tabMiddleware({
       connection: conn,
       sellerPubkey: SELLER.toBase58(),

--- a/src/tab/__tests__/pay-url.test.ts
+++ b/src/tab/__tests__/pay-url.test.ts
@@ -170,6 +170,21 @@ describe('payUrlWithTab', () => {
     );
     expect(decoded.payload).toBeDefined();
     expect(decoded.sessionPublicKey).toBeDefined();
+    expect(decoded.reservationReceipt).toMatchObject({
+      contract: 'dexter-native-tab-open-receipt/v1',
+      transaction: '5'.repeat(88),
+      commitment: 'finalized',
+      buyerSwigAddress: SELLER,
+      vaultPda: SELLER,
+      seller: SELLER,
+      channelId: decoded.payload.channelId,
+      sessionPublicKey: decoded.sessionPublicKey,
+      cumulativeAmountAtomic: decoded.payload.cumulativeAmount,
+      sequenceNumber: decoded.payload.sequenceNumber,
+      reservationAmountAtomic: decoded.payload.cumulativeAmount,
+      currentOutstandingAfterAtomic: decoded.payload.cumulativeAmount,
+    });
+    expect(decoded.reservationReceipt.voucherDigest).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it('2. free URL — 200 with no payment challenge returns paid:false, tab null', async () => {

--- a/src/tab/__tests__/reservation-verifier.test.ts
+++ b/src/tab/__tests__/reservation-verifier.test.ts
@@ -331,8 +331,43 @@ describe('Solana FINAL V2 reservation verifier', () => {
     expect(fixture.getMultipleAccountsInfoAndContext).toHaveBeenCalledTimes(1);
     expect(fixture.getMultipleAccountsInfoAndContext.mock.calls[0][1]).toEqual({
       commitment: 'finalized',
-      minContextSlot: POST_STATE_SLOT,
+      minContextSlot: CONFIRMATION_SLOT,
     });
+  });
+
+  it('never lets an untrusted receipt postStateSlot control the RPC wait fence', async () => {
+    const fixture = makeFixture();
+    fixture.receipt.postStateSlot = Number.MAX_SAFE_INTEGER;
+
+    await expect(verifySolanaFinalVoucherV2Reservation(
+      fixture.connection,
+      fixture.input,
+      fixture.receipt,
+    )).resolves.toBeUndefined();
+
+    expect(fixture.getMultipleAccountsInfoAndContext.mock.calls[0][1]).toEqual({
+      commitment: 'finalized',
+      minContextSlot: CONFIRMATION_SLOT,
+    });
+  });
+
+  it('rejects a reservation transaction visible only at confirmed commitment', async () => {
+    const fixture = makeFixture();
+    fixture.getTransaction.mockImplementation(async (_signature, options) =>
+      options.commitment === 'confirmed' ? fixture.transaction : null);
+
+    await expectCode(
+      verifySolanaFinalVoucherV2Reservation(
+        fixture.connection,
+        fixture.input,
+        fixture.receipt,
+      ),
+      'transaction_missing',
+    );
+    expect(fixture.getTransaction).toHaveBeenCalledWith(
+      fixture.receipt.transaction,
+      { commitment: 'finalized', maxSupportedTransactionVersion: 0 },
+    );
   });
 
   it('rejects a landed transaction with a program error', async () => {
@@ -512,6 +547,34 @@ describe('Solana FINAL V2 reservation verifier', () => {
     );
   });
 
+  it('rejects voucher B with the same amount/outstanding against voucher A\'s transaction Memo', async () => {
+    const fixture = makeFixture();
+    const voucherB: SignedVoucher = {
+      ...fixture.input.voucher,
+      sessionSignature: new Uint8Array(64).fill(0x53),
+    };
+    const identityB = finalVoucherV2ReservationIdentity(voucherB);
+    const inputB: FinalVoucherV2ReservationInput = {
+      ...fixture.input,
+      ...identityB,
+      voucher: voucherB,
+    };
+    const receiptB: FinalVoucherV2ReservationReceipt = {
+      ...fixture.receipt,
+      callerOperationId: identityB.idempotencyKey,
+      voucherDigest: identityB.voucherDigest,
+    };
+
+    await expectCode(
+      verifySolanaFinalVoucherV2Reservation(
+        fixture.connection,
+        inputB,
+        receiptB,
+      ),
+      'reservation_memo_digest',
+    );
+  });
+
   it('rejects a Memo not naming the exact Dexter authority signer', async () => {
     const fixture = makeFixture();
     const settle = fixture.transaction.transaction.message
@@ -564,6 +627,24 @@ describe('Solana FINAL V2 reservation verifier', () => {
         fixture.receipt,
       ),
       'session_frontier',
+    );
+  });
+
+  it('rejects a reservation that was already consumed before seller admission', async () => {
+    const fixture = makeFixture();
+    fixture.sessionData.writeBigUInt64LE(
+      PREVIOUS_CUMULATIVE + RESERVATION_AMOUNT,
+      126,
+    );
+    fixture.sessionData.writeBigUInt64LE(0n, 134);
+
+    await expectCode(
+      verifySolanaFinalVoucherV2Reservation(
+        fixture.connection,
+        fixture.input,
+        fixture.receipt,
+      ),
+      'session_post_state',
     );
   });
 

--- a/src/tab/__tests__/voucher-accounting.test.ts
+++ b/src/tab/__tests__/voucher-accounting.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PublicKey } from '@solana/web3.js';
-import { openTab, TabImpl } from '../tab';
+import { openTab, TabImpl, voucherToHeader } from '../tab';
 import type { Tab, VaultAdapter, SignedVoucher, VoucherPayload } from '../types';
 import { sessionRegisterMessage } from '@dexterai/vault/messages';
 import { DEXTER_VAULT_PROGRAM_ID } from '../instructions';
@@ -257,9 +257,62 @@ describe('Tab.signNextVoucher — commit only after signing', () => {
       sessionNonce: 0x8000_0007,
       reservationAmountAtomic: '5000',
       previousCumulativeAtomic: '0',
-      voucher,
+      voucher: expect.objectContaining({ payload: voucher.payload }),
     }));
+    expect(voucher.reservationReceipt).toEqual(
+      finalizedReservationReceipt(reserveFinalVoucherV2.mock.calls[0][0]),
+    );
     expect(tab.rollbackVoucher(voucher)).toBe(false);
+  });
+
+  it('carries the complete verified receipt through stream() in X-Tab-Voucher', async () => {
+    const { adapter } = makeFakeV2Adapter();
+    const reserveFinalVoucherV2 = vi.fn(async input =>
+      finalizedReservationReceipt(input));
+    const tab = await openTab({
+      vault: adapter,
+      network: 'solana:mainnet',
+      seller: SELLER_PUBKEY,
+      perUnitCap: '0.005',
+      totalCap: '5',
+      reserveFinalVoucherV2,
+    });
+    let header: string | null = null;
+    vi.stubGlobal('fetch', vi.fn(async (_input, init?: RequestInit) => {
+      header = new Headers(init?.headers).get('X-Tab-Voucher');
+      return new Response('data: paid\n\n', { status: 200 });
+    }));
+
+    await tab.stream('https://seller.test/stream');
+
+    expect(header).not.toBeNull();
+    const decoded = JSON.parse(
+      Buffer.from(header!, 'base64').toString('utf8'),
+    );
+    expect(decoded.reservationReceipt).toEqual(
+      finalizedReservationReceipt(reserveFinalVoucherV2.mock.calls[0][0]),
+    );
+  });
+
+  it('refuses to serialize a raw V2 voucher without its reservation receipt', async () => {
+    const { adapter } = makeFakeV2Adapter();
+    const scope = {
+      channelId: '22'.repeat(32),
+      maxAmountAtomic: '5000',
+      revolvingCapacityAtomic: '5000',
+      expiresAtUnix: Math.floor(Date.now() / 1_000) + 3_600,
+      allowedCounterparty: SELLER_PUBKEY,
+    };
+    const session = await adapter.authorizeSession(scope);
+    const raw = await adapter.signWithSession(session, {
+      channelId: scope.channelId,
+      cumulativeAmount: '5000',
+      sequenceNumber: 1,
+    });
+
+    expect(() => voucherToHeader(raw)).toThrow(
+      'native_tab_v2_reservation_receipt_required',
+    );
   });
 
   it('rejects a V2 adapter registration that substitutes the buyer vault identity', async () => {

--- a/src/tab/adapters/solana/reservation-verifier.ts
+++ b/src/tab/adapters/solana/reservation-verifier.ts
@@ -5,15 +5,15 @@
  * Vault `settle_voucher(increment=true)` reservation followed by an SPL Memo
  * carrying the domain-separated digest of the complete FINAL voucher and its
  * reservation identity. The Vault's recorded Dexter authority must sign both
- * instruction accounts. The provider receipt is still checked as durable
- * lifecycle evidence, but it is no longer the only voucher-to-transaction
- * binding.
+ * instruction accounts. Provider-local lifecycle identifiers are only checked
+ * for receipt shape/consistency: economic authority comes from the finalized
+ * transaction, exact Memo, and one coherent post-state read fenced by the
+ * independently fetched transaction slot.
  */
 
 import {
   Connection,
   PublicKey,
-  type Commitment,
 } from '@solana/web3.js';
 import { bytesToHex } from '@noble/hashes/utils';
 import {
@@ -150,7 +150,9 @@ interface ReadTransactionArgs {
 interface ReadPostStateArgs {
   connection: Connection;
   input: FinalVoucherV2ReservationInput;
-  receipt: FinalVoucherV2ReservationReceipt;
+  /** Independently observed finalized reservation-transaction slot. Never a
+   * provider/buyer supplied postStateSlot. */
+  minimumSlot: number;
 }
 
 export interface SolanaReservationVerifierSeams {
@@ -247,8 +249,8 @@ async function readPostState(
   const response = await args.connection.getMultipleAccountsInfoAndContext(
     [bindingPda, vaultPda, sessionPda],
     {
-      commitment: args.receipt.commitment as Commitment,
-      minContextSlot: args.receipt.postStateSlot,
+      commitment: 'finalized',
+      minContextSlot: args.minimumSlot,
     },
   );
   const [bindingAccount, vaultAccount, sessionAccount] = response.value;
@@ -462,7 +464,7 @@ function inspectReservationTransaction(
 
 function inspectPostState(
   input: FinalVoucherV2ReservationInput,
-  receipt: FinalVoucherV2ReservationReceipt,
+  minimumSlot: number,
   authority: string,
   state: SolanaReservationPostStateEvidence,
 ): void {
@@ -475,8 +477,7 @@ function inspectPostState(
 
   if (
     !Number.isSafeInteger(state.contextSlot)
-    || state.contextSlot < receipt.postStateSlot
-    || state.contextSlot < receipt.confirmationSlot
+    || state.contextSlot < minimumSlot
   ) {
     invalid('post_state_slot');
   }
@@ -567,9 +568,9 @@ export async function verifySolanaFinalVoucherV2Reservation(
   const state = await (seams.readPostState ?? readPostState)({
     connection,
     input,
-    receipt,
+    minimumSlot: transaction.slot,
   });
-  inspectPostState(input, receipt, authority, state);
+  inspectPostState(input, transaction.slot, authority, state);
 }
 
 export function createSolanaFinalVoucherV2ReservationVerifier(

--- a/src/tab/from-grant.ts
+++ b/src/tab/from-grant.ts
@@ -448,6 +448,7 @@ export async function tabFromGrant(options: TabFromGrantOptions): Promise<Tab> {
           const receipt = await options.reserveFinalVoucherV2!(input);
           assertFinalVoucherV2ReservationReceipt(input, receipt);
           await vault.verifyFinalVoucherV2Reservation!(input, receipt);
+          return receipt;
         }
       : undefined,
     closeMode: 'settle-only',

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -69,6 +69,7 @@ export type {
   LiveSessionDetails,
   FinalVoucherV2ReservationInput,
   FinalVoucherV2ReservationReceipt,
+  TabSignedVoucher,
   ReserveFinalVoucherV2,
   VerifyFinalVoucherV2Reservation,
 } from './types';

--- a/src/tab/seller/__tests__/middleware-v2-reservation.test.ts
+++ b/src/tab/seller/__tests__/middleware-v2-reservation.test.ts
@@ -1,0 +1,372 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  registrationNonce: 0x8000_0007,
+  verifyRegistrationOnChain: vi.fn(),
+  verifyVoucherSignature: vi.fn(),
+  enforceScope: vi.fn(),
+  verifySolanaFinalVoucherV2Reservation: vi.fn(),
+}));
+
+vi.mock('../verify', async () => {
+  const actual = await vi.importActual<typeof import('../verify')>('../verify');
+  const { PublicKey } = await import('@solana/web3.js');
+  const seller = new PublicKey(
+    '9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin',
+  );
+  return {
+    ...actual,
+    parseRegistration: vi.fn(() => ({
+      programId: new PublicKey(
+        'Hg3wRaydFtJhYrdvYrKECacpJYDsC9Px7yKmpncj2fhc',
+      ),
+      vaultPda: seller,
+      sessionPubkey: new Uint8Array(32),
+      maxAmount: 1_000_000_000n,
+      expiresAt: BigInt(Math.floor(Date.now() / 1_000) + 3_600),
+      allowedCounterparty: seller,
+      nonce: mocks.registrationNonce,
+      maxRevolvingCapacity: 1_000_000n,
+    })),
+    verifyRegistrationOnChain: mocks.verifyRegistrationOnChain,
+    verifyVoucherSignature: mocks.verifyVoucherSignature,
+    enforceScope: mocks.enforceScope,
+  };
+});
+
+vi.mock('../../adapters/solana/reservation-verifier', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../adapters/solana/reservation-verifier')
+  >('../../adapters/solana/reservation-verifier');
+  return {
+    ...actual,
+    verifySolanaFinalVoucherV2Reservation:
+      mocks.verifySolanaFinalVoucherV2Reservation,
+  };
+});
+
+import { tabMiddleware } from '../middleware';
+import { InMemoryChannelLedger } from '../channel-ledger';
+import { OnChainVerificationError } from '../verify';
+import { SolanaFinalVoucherV2ReservationError } from '../../adapters/solana/reservation-verifier';
+
+const SELLER = '9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin';
+const CHANNEL = 'b'.repeat(64);
+
+function chainState(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionAccountVersion: 1,
+    wireVersion: 2,
+    frontierAtomic: '0',
+    spentAtomic: '0',
+    currentOutstandingAtomic: '5000',
+    crystallizedCumulativeAtomic: '0',
+    ...overrides,
+  };
+}
+
+function reservationReceipt(overrides: Record<string, unknown> = {}) {
+  return {
+    contract: 'dexter-native-tab-open-receipt/v1',
+    operationId: 'a'.repeat(64),
+    callerOperationId: `native-tab-v2:${'b'.repeat(64)}`,
+    network: 'solana:mainnet',
+    transaction: '5'.repeat(88),
+    commitment: 'finalized',
+    confirmationSlot: 100,
+    postStateSlot: 101,
+    buyerSwigAddress: SELLER,
+    vaultPda: SELLER,
+    sessionPda: SELLER,
+    seller: SELLER,
+    channelId: CHANNEL,
+    sessionPublicKey: '00'.repeat(32),
+    voucherDigest: 'b'.repeat(64),
+    cumulativeAmountAtomic: '5000',
+    sequenceNumber: 0x8000_0001,
+    providerReceiptId: 'native-tab-provider:test',
+    reservationAmountAtomic: '5000',
+    pendingVoucherCountBefore: 0,
+    pendingVoucherCountAfter: 1,
+    currentOutstandingBeforeAtomic: '0',
+    currentOutstandingAfterAtomic: '5000',
+    ...overrides,
+  };
+}
+
+function voucherHeader(
+  cumulativeAmount: string,
+  sequenceNumber: number,
+  proof: unknown = reservationReceipt({
+    cumulativeAmountAtomic: cumulativeAmount,
+    sequenceNumber,
+  }),
+  includeProof = true,
+): string {
+  return Buffer.from(JSON.stringify({
+    payload: { channelId: CHANNEL, cumulativeAmount, sequenceNumber },
+    sessionPublicKey: '00'.repeat(32),
+    sessionRegistration: '00'.repeat(188),
+    sessionSignature: '00'.repeat(64),
+    ...(includeProof ? { reservationReceipt: proof } : {}),
+  }), 'utf8').toString('base64');
+}
+
+function requestResponse(header: string) {
+  const req: any = { headers: { 'x-tab-voucher': header } };
+  const res: any = new EventEmitter();
+  res.statusCode = 0;
+  res.body = undefined;
+  res.status = function (code: number) { this.statusCode = code; return this; };
+  res.json = function (body: unknown) { this.body = body; return this; };
+  res.setHeader = function () { return this; };
+  res.write = function () { return true; };
+  res.end = function () { return this; };
+  res.flushHeaders = function () {};
+  res.headersSent = false;
+  return { req, res };
+}
+
+function middleware(ledger = new InMemoryChannelLedger()) {
+  return {
+    ledger,
+    handle: tabMiddleware({
+      connection: {} as any,
+      sellerPubkey: SELLER,
+      perUnit: '0.01',
+      network: 'solana:mainnet',
+      settle: 'on-close',
+      ledger,
+      lockCadence: { thresholdAtomic: '1000000000000', onClose: false },
+    }),
+  };
+}
+
+const release = async (res: EventEmitter) => {
+  res.emit('finish');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe('Native Tab V2 seller reservation admission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.registrationNonce = 0x8000_0007;
+    mocks.verifyRegistrationOnChain.mockResolvedValue(chainState());
+    mocks.verifySolanaFinalVoucherV2Reservation.mockResolvedValue(undefined);
+  });
+
+  it('re-reads the authoritative SessionAccount for every V2 voucher', async () => {
+    mocks.verifyRegistrationOnChain
+      .mockResolvedValueOnce(chainState({ currentOutstandingAtomic: '5000' }))
+      .mockResolvedValueOnce(chainState({
+        frontierAtomic: '5000',
+        spentAtomic: '5000',
+        currentOutstandingAtomic: '3000',
+      }));
+    const { ledger, handle } = middleware();
+
+    const first = requestResponse(voucherHeader('5000', 0x8000_0001));
+    const firstNext = vi.fn();
+    await handle(first.req, first.res, firstNext);
+    expect(firstNext).toHaveBeenCalledOnce();
+    await release(first.res);
+
+    const second = requestResponse(voucherHeader(
+      '8000',
+      0x8000_0002,
+      reservationReceipt({
+        cumulativeAmountAtomic: '8000',
+        sequenceNumber: 0x8000_0002,
+        reservationAmountAtomic: '3000',
+        currentOutstandingAfterAtomic: '3000',
+      }),
+    ));
+    const secondNext = vi.fn();
+    await handle(second.req, second.res, secondNext);
+
+    expect(secondNext).toHaveBeenCalledOnce();
+    expect(mocks.verifyRegistrationOnChain).toHaveBeenCalledTimes(2);
+    expect(mocks.verifySolanaFinalVoucherV2Reservation).toHaveBeenCalledTimes(2);
+    expect(mocks.verifySolanaFinalVoucherV2Reservation).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        channelId: CHANNEL,
+        reservationAmountAtomic: '3000',
+        previousCumulativeAtomic: '5000',
+        voucher: expect.objectContaining({
+          payload: expect.objectContaining({
+            cumulativeAmount: '8000',
+            sequenceNumber: 0x8000_0002,
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        transaction: '5'.repeat(88),
+        cumulativeAmountAtomic: '8000',
+        reservationAmountAtomic: '3000',
+      }),
+    );
+    expect(mocks.enforceScope).toHaveBeenLastCalledWith(
+      expect.objectContaining({ previousCumulativeAtomic: '5000' }),
+    );
+    expect((await ledger.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('5000');
+  });
+
+  it('rejects a warm-cache voucher when the active registration was replaced', async () => {
+    mocks.verifyRegistrationOnChain
+      .mockResolvedValueOnce(chainState())
+      .mockRejectedValueOnce(new OnChainVerificationError(
+        'registration_state_mismatch',
+        'active registration changed',
+      ));
+    const { handle } = middleware();
+
+    const first = requestResponse(voucherHeader('5000', 0x8000_0001));
+    await handle(first.req, first.res, vi.fn());
+    await release(first.res);
+
+    const second = requestResponse(voucherHeader('8000', 0x8000_0002));
+    const next = vi.fn();
+    await handle(second.req, second.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(second.res.statusCode).toBe(402);
+    expect(second.res.body).toMatchObject({
+      error: 'invalid_voucher',
+      reason: 'registration_state_mismatch',
+    });
+  });
+
+  it('rejects delivery when currentOutstanding does not equal the uncovered voucher delta', async () => {
+    mocks.verifyRegistrationOnChain.mockResolvedValue(
+      chainState({ currentOutstandingAtomic: '4999' }),
+    );
+    const { ledger, handle } = middleware();
+    const response = requestResponse(voucherHeader('5000', 0x8000_0001));
+    const next = vi.fn();
+
+    await handle(response.req, response.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.res.statusCode).toBe(402);
+    expect(response.res.body).toMatchObject({ reason: 'reservation_mismatch' });
+    expect(await ledger.get(CHANNEL)).toBeNull();
+  });
+
+  it('rejects an already-covered V2 voucher before the route can deliver', async () => {
+    mocks.verifyRegistrationOnChain.mockResolvedValue(chainState({
+      frontierAtomic: '5000',
+      spentAtomic: '5000',
+      currentOutstandingAtomic: '0',
+    }));
+    const { handle } = middleware();
+    const response = requestResponse(voucherHeader('5000', 0x8000_0001));
+    const next = vi.fn();
+
+    await handle(response.req, response.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.res.statusCode).toBe(402);
+    expect(response.res.body).toMatchObject({ reason: 'voucher_already_covered' });
+  });
+
+  it('rejects a V2 voucher when the authoritative session reports the V1 wire', async () => {
+    mocks.verifyRegistrationOnChain.mockResolvedValue(chainState({ wireVersion: 1 }));
+    const { handle } = middleware();
+    const response = requestResponse(voucherHeader('5000', 0x8000_0001));
+    const next = vi.fn();
+
+    await handle(response.req, response.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.res.statusCode).toBe(402);
+    expect(response.res.body).toMatchObject({ reason: 'wire_version_mismatch' });
+  });
+
+  it('rejects a V1 voucher sequence carried by a V2 registration', async () => {
+    const { handle } = middleware();
+    const response = requestResponse(voucherHeader('5000', 1));
+    const next = vi.fn();
+
+    await handle(response.req, response.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.res.statusCode).toBe(402);
+    expect(response.res.body).toMatchObject({ reason: 'wire_version_mismatch' });
+  });
+
+  it('fails closed before delivery when a V2 envelope omits its reservation proof', async () => {
+    const { handle } = middleware();
+    const response = requestResponse(voucherHeader(
+      '5000',
+      0x8000_0001,
+      undefined,
+      false,
+    ));
+    const next = vi.fn();
+
+    await handle(response.req, response.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.res.body).toMatchObject({
+      reason: 'reservation_proof_missing',
+    });
+    expect(mocks.verifySolanaFinalVoucherV2Reservation).not.toHaveBeenCalled();
+  });
+
+  it.each([null, 'not-an-object', []])(
+    'fails closed when the V2 reservation proof is malformed: %j',
+    async proof => {
+      const { handle } = middleware();
+      const response = requestResponse(voucherHeader(
+        '5000',
+        0x8000_0001,
+        proof,
+      ));
+      const next = vi.fn();
+
+      await handle(response.req, response.res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(response.res.body).toMatchObject({
+        reason: 'reservation_proof_invalid',
+      });
+      expect(mocks.verifySolanaFinalVoucherV2Reservation).not.toHaveBeenCalled();
+    },
+  );
+
+  it('maps an exact Memo/transaction proof failure to a fail-closed 402', async () => {
+    mocks.verifySolanaFinalVoucherV2Reservation.mockRejectedValueOnce(
+      new SolanaFinalVoucherV2ReservationError('reservation_memo_digest'),
+    );
+    const { handle } = middleware();
+    const response = requestResponse(voucherHeader('5000', 0x8000_0001));
+    const next = vi.fn();
+
+    await handle(response.req, response.res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.res.body).toMatchObject({
+      reason: 'reservation_proof_invalid',
+    });
+  });
+
+  it('preserves historical V1 registration caching without a per-voucher chain read', async () => {
+    mocks.registrationNonce = 7;
+    mocks.verifyRegistrationOnChain.mockResolvedValue(undefined);
+    const { handle } = middleware();
+
+    const first = requestResponse(voucherHeader('5000', 1));
+    await handle(first.req, first.res, vi.fn());
+    await release(first.res);
+
+    const second = requestResponse(voucherHeader('8000', 2));
+    const next = vi.fn();
+    await handle(second.req, second.res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(mocks.verifyRegistrationOnChain).toHaveBeenCalledTimes(1);
+    expect(mocks.verifySolanaFinalVoucherV2Reservation).not.toHaveBeenCalled();
+  });
+});

--- a/src/tab/seller/__tests__/verify-onchain-registration.test.ts
+++ b/src/tab/seller/__tests__/verify-onchain-registration.test.ts
@@ -1,18 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Keypair } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
 import type { Connection } from '@solana/web3.js';
-
-const mocks = vi.hoisted(() => ({
-  fetchSessionAccount: vi.fn(),
-}));
-
-vi.mock('@dexterai/vault/session', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@dexterai/vault/session')>();
-  return {
-    ...actual,
-    fetchSessionAccount: mocks.fetchSessionAccount,
-  };
-});
 
 import { sessionRegisterMessage } from '@dexterai/vault/messages';
 import { deriveSessionPda } from '@dexterai/vault/session';
@@ -78,26 +66,62 @@ function activeState() {
   };
 }
 
+function accountData(state = activeState()): Buffer {
+  const data = Buffer.alloc(162);
+  Buffer.from([74, 34, 65, 133, 96, 163, 80, 69]).copy(data, 0);
+  data.writeUInt8(state.version, 8);
+  data.writeUInt8(state.bump, 9);
+  new PublicKey(state.vault).toBuffer().copy(data, 10);
+  Buffer.from(state.session.sessionPubkey).copy(data, 42);
+  data.writeBigUInt64LE(state.session.maxAmount, 74);
+  data.writeBigInt64LE(BigInt(state.session.expiresAt), 82);
+  new PublicKey(state.session.allowedCounterparty).toBuffer().copy(data, 90);
+  data.writeUInt32LE(state.session.nonce, 122);
+  data.writeBigUInt64LE(state.session.spent, 126);
+  data.writeBigUInt64LE(state.session.currentOutstanding, 134);
+  data.writeBigUInt64LE(state.session.maxRevolvingCapacity, 142);
+  data.writeBigUInt64LE(state.session.crystallizedCumulative, 150);
+  data.writeUInt32LE(state.session.lastLockedSequence, 158);
+  return data;
+}
+
+function accountInfo(
+  state = activeState(),
+  owner: PublicKey = DEXTER_VAULT_PROGRAM_ID,
+) {
+  return {
+    data: accountData(state),
+    owner,
+    executable: false,
+    lamports: 1,
+    rentEpoch: 0,
+  };
+}
+
+const getAccountInfo = vi.fn();
+const connection = { getAccountInfo } as unknown as Connection;
+
 describe('verifyRegistrationOnChain exact immutable registration witness', () => {
   beforeEach(() => {
-    mocks.fetchSessionAccount.mockReset();
-    mocks.fetchSessionAccount.mockResolvedValue(activeState());
+    getAccountInfo.mockReset();
+    getAccountInfo.mockResolvedValue(accountInfo());
   });
 
-  it('accepts the exact 188-byte registration and returns only mutable frontier data', async () => {
+  it('accepts the exact 188-byte registration and returns the authoritative V2 reservation state', async () => {
     await expect(verifyRegistrationOnChain(
-      {} as Connection,
+      connection,
       registration(),
     )).resolves.toEqual({
+      sessionAccountVersion: 1,
+      wireVersion: 2,
       frontierAtomic: '20',
       spentAtomic: '10',
+      currentOutstandingAtomic: '0',
       crystallizedCumulativeAtomic: '20',
     });
-    expect(mocks.fetchSessionAccount).toHaveBeenCalledWith(
-      expect.anything(),
-      VAULT,
-      SELLER,
-      DEXTER_VAULT_PROGRAM_ID,
+    expect(getAccountInfo).toHaveBeenCalledWith(
+      SESSION_PDA,
+      'finalized',
     );
   });
 
@@ -109,7 +133,7 @@ describe('verifyRegistrationOnChain exact immutable registration witness', () =>
     ['revolving capacity', { maxRevolvingCapacity: 900n }],
   ] as const)('rejects a forged %s before seller delivery', async (_label, forged) => {
     const error = await verifyRegistrationOnChain(
-      {} as Connection,
+      connection,
       registration(forged),
     ).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(OnChainVerificationError);
@@ -118,5 +142,47 @@ describe('verifyRegistrationOnChain exact immutable registration witness', () =>
         ? 'session_pubkey_mismatch'
         : 'registration_state_mismatch',
     });
+  });
+
+  it('rejects a V2 voucher registration when the active SessionAccount is V1', async () => {
+    const state = activeState();
+    state.session.nonce = 7;
+    getAccountInfo.mockResolvedValue(accountInfo(state));
+
+    const error = await verifyRegistrationOnChain(
+      connection,
+      registration(),
+    ).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(OnChainVerificationError);
+    expect(error).toMatchObject({ reason: 'wire_version_mismatch' });
+  });
+
+  it('rejects a reservation visible only at confirmed commitment', async () => {
+    getAccountInfo.mockImplementation(async (_address, commitment) => (
+      commitment === 'confirmed' ? accountInfo() : null
+    ));
+
+    const error = await verifyRegistrationOnChain(
+      connection,
+      registration(),
+    ).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(OnChainVerificationError);
+    expect(error).toMatchObject({ reason: 'session_not_active' });
+    expect(getAccountInfo).toHaveBeenCalledOnce();
+    expect(getAccountInfo).toHaveBeenCalledWith(SESSION_PDA, 'finalized');
+  });
+
+  it('rejects a finalized PDA owned by any program other than the registration program', async () => {
+    getAccountInfo.mockResolvedValue(accountInfo(
+      activeState(),
+      Keypair.generate().publicKey,
+    ));
+
+    const error = await verifyRegistrationOnChain(
+      connection,
+      registration(),
+    ).catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(OnChainVerificationError);
+    expect(error).toMatchObject({ reason: 'wrong_program' });
   });
 });

--- a/src/tab/seller/__tests__/verify-wire-version.test.ts
+++ b/src/tab/seller/__tests__/verify-wire-version.test.ts
@@ -1,0 +1,50 @@
+import { Keypair } from '@solana/web3.js';
+import { describe, expect, it } from 'vitest';
+
+import { sessionRegisterMessage } from '@dexterai/vault/messages';
+import { DEXTER_VAULT_PROGRAM_ID } from '../../instructions';
+import type { SignedVoucher } from '../../types';
+import { verifyVoucherSignature } from '../verify';
+
+const VAULT = Keypair.generate().publicKey;
+const SELLER = Keypair.generate().publicKey;
+const SESSION = Keypair.generate().publicKey.toBytes();
+const CHANNEL = new Uint8Array(32).fill(7);
+
+function voucher(registrationNonce: number, sequenceNumber: number): SignedVoucher {
+  return {
+    payload: {
+      channelId: Buffer.from(CHANNEL).toString('hex'),
+      cumulativeAmount: '1',
+      sequenceNumber,
+    },
+    sessionPublicKey: SESSION,
+    sessionRegistration: sessionRegisterMessage({
+      programId: DEXTER_VAULT_PROGRAM_ID,
+      vaultPda: VAULT,
+      sessionPubkey: SESSION,
+      maxAmount: 100n,
+      expiresAt: 2_000_000_000n,
+      allowedCounterparty: SELLER,
+      nonce: registrationNonce,
+      maxRevolvingCapacity: 100n,
+    }),
+    sessionSignature: new Uint8Array(64),
+  };
+}
+
+describe('seller voucher wire-version binding', () => {
+  it('rejects a V1 sequence under an active V2 registration', () => {
+    expect(() => verifyVoucherSignature(
+      voucher(0x8000_0007, 1),
+      CHANNEL,
+    )).toThrow(/voucher wire V1 does not match registration wire V2/);
+  });
+
+  it('rejects a V2 sequence under an active historical V1 registration', () => {
+    expect(() => verifyVoucherSignature(
+      voucher(7, 0x8000_0001),
+      CHANNEL,
+    )).toThrow(/voucher wire V2 does not match registration wire V1/);
+  });
+});

--- a/src/tab/seller/middleware.ts
+++ b/src/tab/seller/middleware.ts
@@ -3,24 +3,32 @@
  *
  * Wire shape:
  *   - Buyer sends each paid request with header `X-Tab-Voucher: <base64-json>`
- *   - The voucher JSON is the SignedVoucher shape (payload + session pubkey +
- *     registration + signature)
- *   - On the FIRST voucher of a session, the middleware parses the
+ *   - The envelope contains the SignedVoucher fields (payload + session pubkey
+ *     + registration + signature). V2 additionally carries the complete
+ *     FinalVoucherV2ReservationReceipt used only as an untrusted proof locator.
+ *   - On the FIRST V1 voucher of a session, the middleware parses the
  *     registration, verifies it against the on-chain vault (one RPC call),
- *     and caches the result
+ *     and caches the result. V2 re-reads the SessionAccount on EVERY voucher
+ *     because the live reservation is the seller's delivery authorization.
  *   - On EVERY voucher, the middleware verifies the session-key signature
  *     and enforces scope (cap, expiry, counterparty, monotonicity)
  *   - The route handler reads `req.tab` and either runs a stream against it
  *     or rejects with 402 Payment Required
  *
- * The middleware never blocks on chain in the per-voucher hot path. The
- * one-time on-chain read is amortized across the entire session.
+ * Historical V1 keeps the cached, no-chain hot path. Native Tab V2 deliberately
+ * performs finalized registration/reservation admission on every voucher and
+ * independently proves the exact authority-signed settle + Memo before delivery.
  */
 
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import { Connection, PublicKey } from '@solana/web3.js';
 
-import type { SignedVoucher, HumanAmount, AtomicAmount } from '../types';
+import type {
+  SignedVoucher,
+  HumanAmount,
+  AtomicAmount,
+  FinalVoucherV2ReservationReceipt,
+} from '../types';
 import type {
   SellerTab,
   TabMiddlewareOptions,
@@ -32,7 +40,9 @@ import {
   verifyRegistrationOnChain,
   verifyVoucherSignature,
   enforceScope,
+  nativeTabWireVersion,
   type ParsedRegistration,
+  type OnChainSessionFrontier,
   InvalidRegistrationError,
   OnChainVerificationError,
   InvalidVoucherSignatureError,
@@ -41,6 +51,12 @@ import {
 
 import { InMemoryChannelLedger, withChannelLock, type ChannelLedger, type ChannelLedgerEntry } from './channel-ledger';
 import { atomicToHuman, humanToAtomic, DEFAULT_FACILITATOR_URL } from '../tab';
+import { finalVoucherV2ReservationIdentity } from '../reservation';
+import {
+  SolanaFinalVoucherV2ReservationError,
+  verifySolanaFinalVoucherV2Reservation,
+} from '../adapters/solana/reservation-verifier';
+import { deriveSessionPda } from '@dexterai/vault/session';
 import { maybeCrystallize, crystallizeNow, isGateRefused, type LockCadence } from './crystallize';
 
 // ── Augmented Express request type ─────────────────────────────────────
@@ -60,7 +76,7 @@ export interface TabMiddlewareConfig extends TabMiddlewareOptions {
   sellerPubkey: string | PublicKey;
 }
 
-/** Header the buyer sends with each paid request. base64-encoded JSON of SignedVoucher. */
+/** Header the buyer sends with each paid request. Base64 JSON voucher envelope. */
 export const TAB_VOUCHER_HEADER = 'x-tab-voucher';
 
 // ── Session cache ──────────────────────────────────────────────────────
@@ -144,7 +160,12 @@ export class SellerTabImpl implements SellerTab {
 
 // ── Voucher decoding ───────────────────────────────────────────────────
 
-function decodeVoucherHeader(header: unknown): SignedVoucher {
+interface DecodedVoucherHeader {
+  voucher: SignedVoucher;
+  reservationReceipt: unknown;
+}
+
+function decodeVoucherHeader(header: unknown): DecodedVoucherHeader {
   if (typeof header !== 'string' || header.length === 0) {
     throw new InvalidVoucherError('signature_invalid', `missing ${TAB_VOUCHER_HEADER} header`);
   }
@@ -165,10 +186,13 @@ function decodeVoucherHeader(header: unknown): SignedVoucher {
     throw new InvalidVoucherError('signature_invalid', 'missing required fields');
   }
   return {
-    payload: parsed.payload,
-    sessionPublicKey: hexToBytes(parsed.sessionPublicKey),
-    sessionRegistration: hexToBytes(parsed.sessionRegistration),
-    sessionSignature: hexToBytes(parsed.sessionSignature),
+    voucher: {
+      payload: parsed.payload,
+      sessionPublicKey: hexToBytes(parsed.sessionPublicKey),
+      sessionRegistration: hexToBytes(parsed.sessionRegistration),
+      sessionSignature: hexToBytes(parsed.sessionSignature),
+    },
+    reservationReceipt: parsed.reservationReceipt,
   };
 }
 
@@ -225,22 +249,24 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       // 1. Decode the voucher off the header.
-      const voucher = decodeVoucherHeader(req.headers[TAB_VOUCHER_HEADER]);
+      const decoded = decodeVoucherHeader(req.headers[TAB_VOUCHER_HEADER]);
+      const voucher = decoded.voucher;
       const channelId = voucher.payload.channelId;
       const channelIdBytes = channelIdHexToBytes(channelId);
 
       // 2. Look up (or build) the session entry.
       let entry = cache.get(channelId);
       // Chain frontier (max(spent, crystallized)) read as a by-product of the
-      // one-time on-chain verification. Non-null ONLY on the first voucher of
-      // a session in this process — used further down to seed a FRESH ledger
-      // entry's delivered baseline so a resumed session (or a restarted
-      // in-memory ledger) can't re-grant budget that already settled/locked.
+      // registration check. Historical V1 reads it only on the first voucher;
+      // V2 refreshes it on every voucher together with currentOutstanding.
       let chainFrontierAtomic: string | null = null;
+      let onChain: OnChainSessionFrontier | undefined;
+      let registrationChecked = false;
       if (!entry) {
         // First voucher for this channel — parse + verify the registration.
         const parsed = parseRegistration(voucher.sessionRegistration);
-        const onChain = await verifyRegistrationOnChain(config.connection, parsed);
+        onChain = await verifyRegistrationOnChain(config.connection, parsed);
+        registrationChecked = true;
         // Defensive `?.`: custom/mocked verifiers may still return void.
         chainFrontierAtomic = onChain?.frontierAtomic ?? null;
         // Seed the monotonicity/increment baseline from the durable ledger's
@@ -265,23 +291,122 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
         );
       }
 
+      const registrationWireVersion = nativeTabWireVersion(
+        entry.registration.nonce,
+      );
+      const voucherWireVersion = nativeTabWireVersion(
+        voucher.payload.sequenceNumber,
+      );
+      if (voucherWireVersion !== registrationWireVersion) {
+        throw new InvalidVoucherError(
+          'wire_version_mismatch',
+          `voucher is V${voucherWireVersion}, active registration is V${registrationWireVersion}`,
+        );
+      }
+
+      let reservationReceipt: FinalVoucherV2ReservationReceipt | undefined;
+      if (registrationWireVersion === 2) {
+        if (decoded.reservationReceipt === undefined) {
+          throw new InvalidVoucherError(
+            'reservation_proof_missing',
+            'Native Tab V2 requires the verified reservation receipt in the voucher envelope',
+          );
+        }
+        if (
+          decoded.reservationReceipt === null
+          || typeof decoded.reservationReceipt !== 'object'
+          || Array.isArray(decoded.reservationReceipt)
+        ) {
+          throw new InvalidVoucherError(
+            'reservation_proof_invalid',
+            'reservationReceipt must be an object',
+          );
+        }
+        reservationReceipt = decoded.reservationReceipt as
+          FinalVoucherV2ReservationReceipt;
+      }
+
+      // A V2 registration cache is identity memory, never current authority.
+      // Re-read before EVERY delivery so replacement/revoke/expiry and the
+      // exact finalized reservation cannot be bypassed by a warm process.
+      if (registrationWireVersion === 2 && !registrationChecked) {
+        onChain = await verifyRegistrationOnChain(
+          config.connection,
+          entry.registration,
+        );
+        registrationChecked = true;
+        chainFrontierAtomic = onChain?.frontierAtomic ?? null;
+      }
+
       // 3. Verify the voucher signature over the canonical message.
       verifyVoucherSignature(voucher, channelIdBytes);
 
-      // 4. Enforce scope: cap, expiry, counterparty, monotonicity.
+      const cumulative = BigInt(voucher.payload.cumulativeAmount);
+      const previous = BigInt(entry.lastCumulativeAtomic);
+      let authorizationBaseline = previous;
+      let reservationDelta: bigint | null = null;
+
+      if (registrationWireVersion === 2) {
+        // V2 must fail closed if a custom verifier omits any authoritative
+        // field. A reservation is exact: currentOutstanding covers only the
+        // voucher delta above the greater of the seller's accepted cumulative
+        // and the terminal chain frontier. Anything at/below that frontier is
+        // already covered and cannot buy delivery again.
+        if (onChain?.wireVersion !== 2) {
+          throw new InvalidVoucherError(
+            'wire_version_mismatch',
+            `active SessionAccount is V${onChain?.wireVersion ?? 'unknown'}, voucher is V2`,
+          );
+        }
+        if (
+          onChain.sessionAccountVersion !== 1
+          || chainFrontierAtomic === null
+          || onChain.currentOutstandingAtomic === undefined
+        ) {
+          throw new InvalidVoucherError(
+            'reservation_mismatch',
+            'authoritative V2 SessionAccount reservation evidence is incomplete',
+          );
+        }
+        const chainFrontier = parseOnChainAtomic(
+          chainFrontierAtomic,
+          'frontierAtomic',
+        );
+        if (chainFrontier > authorizationBaseline) {
+          authorizationBaseline = chainFrontier;
+        }
+        if (cumulative <= authorizationBaseline) {
+          throw new InvalidVoucherError(
+            'voucher_already_covered',
+            `cumulative ${cumulative} is not above covered frontier ${authorizationBaseline}`,
+          );
+        }
+        reservationDelta = cumulative - authorizationBaseline;
+        const currentOutstanding = parseOnChainAtomic(
+          onChain.currentOutstandingAtomic,
+          'currentOutstandingAtomic',
+        );
+        if (currentOutstanding !== reservationDelta) {
+          throw new InvalidVoucherError(
+            'reservation_mismatch',
+            `currentOutstanding ${currentOutstanding} does not equal voucher delta ${reservationDelta}`,
+          );
+        }
+      }
+
+      // 4. Enforce scope: cap, expiry, counterparty, monotonicity. V2 uses the
+      // authoritative covered baseline; V1 retains its cached seller baseline.
       enforceScope({
         registration: entry.registration,
         voucher,
         expectedCounterparty: sellerPubkey,
-        previousCumulativeAtomic: entry.lastCumulativeAtomic,
+        previousCumulativeAtomic: authorizationBaseline.toString(),
       });
 
       // 5. Bound per-voucher increment. Protects against a giant single
       //    voucher slipping through; the buyer's perUnitCap should prevent
       //    this from the client side but the seller still defends.
-      const cumulative = BigInt(voucher.payload.cumulativeAmount);
-      const previous = BigInt(entry.lastCumulativeAtomic);
-      const increment = cumulative - previous;
+      const increment = cumulative - authorizationBaseline;
       if (increment > maxPerVoucherAtomic) {
         throw new ScopeViolationError(
           'cumulative_exceeds_cap',
@@ -289,7 +414,55 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
         );
       }
 
-      // 5b. One live stream per channel: acquire the lease or reject. Closes the
+      // 5b. V2 delivery requires the exact authority-signed reservation, not
+      // merely an equal outstanding amount. The receipt supplies an untrusted
+      // transaction locator and buyer Swig identity; the verifier fetches that
+      // transaction at finalized, recomputes the Memo from this voucher, and
+      // proves the coherent Vault/binding/session post-state independently.
+      if (registrationWireVersion === 2) {
+        if (!reservationReceipt || reservationDelta === null) {
+          throw new InvalidVoucherError(
+            'reservation_proof_missing',
+            'Native Tab V2 reservation proof was not carried through admission',
+          );
+        }
+        const [sessionPda] = deriveSessionPda(
+          entry.registration.vaultPda,
+          entry.registration.allowedCounterparty,
+          entry.registration.programId,
+        );
+        const identity = finalVoucherV2ReservationIdentity(voucher);
+        try {
+          await verifySolanaFinalVoucherV2Reservation(
+            config.connection,
+            {
+              network: config.network,
+              programId: entry.registration.programId.toBase58(),
+              buyerSwigAddress: reservationReceipt.buyerSwigAddress,
+              vaultPda: entry.registration.vaultPda.toBase58(),
+              sessionPda: sessionPda.toBase58(),
+              seller: entry.registration.allowedCounterparty.toBase58(),
+              channelId,
+              sessionNonce: entry.registration.nonce,
+              reservationAmountAtomic: reservationDelta.toString(),
+              previousCumulativeAtomic: authorizationBaseline.toString(),
+              ...identity,
+              voucher,
+            },
+            reservationReceipt,
+          );
+        } catch (error) {
+          if (error instanceof SolanaFinalVoucherV2ReservationError) {
+            throw new InvalidVoucherError(
+              'reservation_proof_invalid',
+              error.message,
+            );
+          }
+          throw error;
+        }
+      }
+
+      // 5c. One live stream per channel: acquire the lease or reject. Closes the
       //     concurrent-same-channel over-delivery rug.
       const leaseTtlMs = config.leaseTtlMs ?? 300_000;
       if (!(await ledger.tryAcquireLease(channelId, leaseTtlMs))) {
@@ -436,15 +609,20 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       const prior = await ledger.get(channelId);
       // A ledger entry is FRESH when it has never seen a voucher or delivery —
       // tryAcquireLease auto-creates zeroed entries, so `prior != null` alone
-      // does not mean history exists. Only a fresh entry gets seeded from the
-      // chain frontier; real history is never overwritten (multi-instance
-      // reconciliation stays out of scope, as documented on the meter).
-      const priorIsFresh =
-        !prior?.lastVoucher && BigInt(prior?.deliveredCumulativeAtomic ?? '0') === 0n;
-      const seedAtomic =
-        chainFrontierAtomic !== null && priorIsFresh && BigInt(chainFrontierAtomic) > 0n
-          ? chainFrontierAtomic
-          : null;
+      // does not mean history exists. V1 retains the historical fresh-only
+      // seed. V2 advances even an existing ledger's delivery floor when the
+      // authoritative chain frontier has moved, preventing another process's
+      // already-settled delivery from becoming fresh budget here.
+      const priorDelivered = BigInt(prior?.deliveredCumulativeAtomic ?? '0');
+      const priorIsFresh = !prior?.lastVoucher && priorDelivered === 0n;
+      const frontier = chainFrontierAtomic === null
+        ? null
+        : BigInt(chainFrontierAtomic);
+      const seedAtomic = frontier !== null && frontier > priorDelivered && (
+        registrationWireVersion === 2 || priorIsFresh
+      )
+        ? frontier.toString()
+        : null;
       if (seedAtomic !== null) {
         console.info(
           `[tab/seller] channel ${channelId.slice(0, 16)}… resumed: seeding delivered ` +
@@ -559,6 +737,16 @@ function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
     difference |= left[index] ^ right[index];
   }
   return difference === 0;
+}
+
+function parseOnChainAtomic(value: string, field: string): bigint {
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new InvalidVoucherError(
+      'reservation_mismatch',
+      `authoritative ${field} is not a canonical atomic amount`,
+    );
+  }
+  return BigInt(value);
 }
 
 /** Pull the SellerTab off a request. Throws if the middleware didn't run. */

--- a/src/tab/seller/types.ts
+++ b/src/tab/seller/types.ts
@@ -146,6 +146,11 @@ export class InvalidVoucherError extends Error {
       | 'session_expired'
       | 'wrong_counterparty'
       | 'non_monotonic'
+      | 'wire_version_mismatch'
+      | 'reservation_mismatch'
+      | 'voucher_already_covered'
+      | 'reservation_proof_missing'
+      | 'reservation_proof_invalid'
       | 'channel_busy',
     detail?: string,
   ) {

--- a/src/tab/seller/verify.ts
+++ b/src/tab/seller/verify.ts
@@ -10,10 +10,10 @@
  *      for passkey verification.
  *
  *   2. verifyRegistrationOnChain(connection, registration, programId)
- *      Reads the vault account on chain ONCE per session and verifies that
- *      the buyer's passkey would have produced the registration's signature.
- *      Cached after the first call; subsequent vouchers in the same session
- *      reuse the cached result.
+ *      Reads the authoritative SessionAccount and verifies that the complete
+ *      registration still matches it. Historical V1 sellers may cache this;
+ *      Native Tab V2 sellers must repeat it for every reserved voucher because
+ *      currentOutstanding is the per-voucher delivery fence.
  *
  *   3. verifyVoucherSignature(voucher, sessionPublicKey, channelIdBytes)
  *      Verifies the session-key signature over the 44-byte voucher payload.
@@ -34,8 +34,8 @@ import { voucherPayloadMessage } from '../messages';
 import { DEXTER_VAULT_PROGRAM_ID } from '../instructions';
 // V6: sessions live in their own per-counterparty PDA, not inline in the vault.
 import {
+  decodeSessionAccount,
   deriveSessionPda,
-  fetchSessionAccount,
   isSessionLive,
 } from '@dexterai/vault/session';
 import {
@@ -70,6 +70,16 @@ export interface ParsedRegistration {
   allowedCounterparty: PublicKey;
   nonce: number;
   maxRevolvingCapacity: bigint;     // u64 at [180..188)
+}
+
+export type NativeTabWireVersion = 1 | 2;
+
+/** Both the registration nonce and voucher sequence reserve their high bit as
+ * the Native Tab V2 wire marker. Keeping this conversion shared prevents the
+ * seller from interpreting a V1 registration with a V2 voucher (or vice
+ * versa) under different signature/settlement rules. */
+export function nativeTabWireVersion(taggedU32: number): NativeTabWireVersion {
+  return taggedU32 >= 0x8000_0000 ? 2 : 1;
 }
 
 export class InvalidRegistrationError extends Error {
@@ -168,6 +178,7 @@ export class OnChainVerificationError extends Error {
       | 'session_not_active'
       | 'session_pubkey_mismatch'
       | 'registration_state_mismatch'
+      | 'wire_version_mismatch'
       | 'wrong_program',
     detail?: string,
   ) {
@@ -176,20 +187,25 @@ export class OnChainVerificationError extends Error {
   }
 }
 
-/** The session's on-chain terminal odometers, read as a by-product of the
- *  first-voucher verification. `frontierAtomic` = max(spent, crystallized) —
- *  the floor below which no voucher can ever settle or lock again. The
- *  middleware seeds a FRESH channel's delivered baseline from it so a resumed
- *  session can't re-consume budget that already settled/crystallized. */
+/** The session's authoritative on-chain delivery evidence.
+ * `frontierAtomic` = max(spent, crystallized), the floor below which no voucher
+ * can ever settle or lock again. V2 additionally requires
+ * `currentOutstandingAtomic` to equal the voucher's uncovered delta. */
 export interface OnChainSessionFrontier {
+  /** Program account layout version. A live SessionAccount is currently 1. */
+  sessionAccountVersion: number;
+  /** V1/V2 authorization wire selected by the active registration nonce. */
+  wireVersion: NativeTabWireVersion;
   frontierAtomic: AtomicAmount;
   spentAtomic: AtomicAmount;
+  currentOutstandingAtomic: AtomicAmount;
   crystallizedCumulativeAtomic: AtomicAmount;
 }
 
 /**
  * Verify a registration against on-chain state. Throws on any mismatch;
- * on success returns the session's terminal odometers (frontier).
+ * on success returns the session's live version, terminal frontier, and exact
+ * outstanding reservation.
  *
  * V6: a session is its own PDA ([b"session", vault, allowed_counterparty]),
  * NOT an inline field on the vault. We read that SessionAccount and confirm it
@@ -199,25 +215,53 @@ export interface OnChainSessionFrontier {
  * the secp256r1 precompile inside that tx — the seller just confirms the
  * on-chain witness still holds.
  *
- * fetchSessionAccount reads at the connection's commitment; pass a connection
- * configured at the commitment the buyer's registration was confirmed to (the
- * adapter waits for visibility before openTab returns).
+ * The seller reads the exact derived SessionAccount PDA at `finalized`; a
+ * confirmed-only reservation is intentionally insufficient for delivery.
  */
 export async function verifyRegistrationOnChain(
   connection: Connection,
   registration: ParsedRegistration,
 ): Promise<OnChainSessionFrontier> {
-  const state = await fetchSessionAccount(
-    connection,
+  const [expectedSessionPda] = deriveSessionPda(
     registration.vaultPda,
     registration.allowedCounterparty,
     registration.programId,
   );
+  // Vault 0.43.1's fetchSessionAccount hardcodes `confirmed`. Do not use it
+  // here: seller delivery is irreversible and V2 reservation admission must
+  // be rooted in finalized state.
+  const account = await connection.getAccountInfo(
+    expectedSessionPda,
+    'finalized',
+  );
 
-  if (!state || state.version === 0) {
+  if (!account) {
     throw new OnChainVerificationError(
       'session_not_active',
-      'no live SessionAccount PDA for this (vault, counterparty) — revoked, expiry-swept, or never registered',
+      'no finalized SessionAccount PDA for this (vault, counterparty) — reservation may be confirmed-only, revoked, expiry-swept, or never registered',
+    );
+  }
+  if (!account.owner.equals(registration.programId)) {
+    throw new OnChainVerificationError(
+      'wrong_program',
+      `SessionAccount owner ${account.owner.toBase58()} != ${registration.programId.toBase58()}`,
+    );
+  }
+
+  let state: ReturnType<typeof decodeSessionAccount>;
+  try {
+    state = decodeSessionAccount(expectedSessionPda, account.data);
+  } catch (error) {
+    throw new OnChainVerificationError(
+      'registration_state_mismatch',
+      `finalized SessionAccount decode failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (state.version === 0) {
+    throw new OnChainVerificationError(
+      'session_not_active',
+      'finalized SessionAccount is cleared',
     );
   }
 
@@ -235,6 +279,15 @@ export async function verifyRegistrationOnChain(
     );
   }
 
+  const registrationWireVersion = nativeTabWireVersion(registration.nonce);
+  const activeWireVersion = nativeTabWireVersion(state.session.nonce);
+  if (activeWireVersion !== registrationWireVersion) {
+    throw new OnChainVerificationError(
+      'wire_version_mismatch',
+      `active SessionAccount is V${activeWireVersion}, voucher registration is V${registrationWireVersion}`,
+    );
+  }
+
   // The SessionAccount is the passkey-verified source of truth for EVERY
   // immutable field in the 188-byte registration, not merely the session
   // public key.  A caller can freely edit the registration bytes carried in a
@@ -245,11 +298,6 @@ export async function verifyRegistrationOnChain(
   // releases seller output.  Mutable meters (spent/outstanding/crystallized/
   // lastLockedSequence) are intentionally excluded because they advance after
   // registration.
-  const [expectedSessionPda] = deriveSessionPda(
-    registration.vaultPda,
-    registration.allowedCounterparty,
-    registration.programId,
-  );
   const expiryIsExact =
     Number.isSafeInteger(state.session.expiresAt)
     && BigInt(state.session.expiresAt) === registration.expiresAt;
@@ -278,8 +326,11 @@ export async function verifyRegistrationOnChain(
   const crystallized = state.session.crystallizedCumulative;
   const frontier = spent > crystallized ? spent : crystallized;
   return {
+    sessionAccountVersion: state.version,
+    wireVersion: activeWireVersion,
     frontierAtomic: frontier.toString(),
     spentAtomic: spent.toString(),
+    currentOutstandingAtomic: state.session.currentOutstanding.toString(),
     crystallizedCumulativeAtomic: crystallized.toString(),
   };
 }
@@ -325,6 +376,15 @@ export function verifyVoucherSignature(
     );
   }
   const v2 = registration.nonce >= 0x8000_0000;
+  const registrationWireVersion = nativeTabWireVersion(registration.nonce);
+  const voucherWireVersion = nativeTabWireVersion(
+    voucher.payload.sequenceNumber,
+  );
+  if (registrationWireVersion !== voucherWireVersion) {
+    throw new InvalidVoucherSignatureError(
+      `voucher wire V${voucherWireVersion} does not match registration wire V${registrationWireVersion}`,
+    );
+  }
   let message: Uint8Array;
   if (v2) {
     sessionVoucherV2AuthorizationNonce(registration.nonce);

--- a/src/tab/tab.ts
+++ b/src/tab/tab.ts
@@ -30,6 +30,8 @@ import type {
   VaultAdapter,
   VoucherPayload,
   SignedVoucher,
+  TabSignedVoucher,
+  FinalVoucherV2ReservationReceipt,
 } from './types';
 import {
   TabClosedError,
@@ -125,7 +127,7 @@ interface TabInternals {
     voucher: SignedVoucher;
     incrementAtomic: AtomicAmount;
     previousCumulativeAtomic: AtomicAmount;
-  }) => Promise<void>;
+  }) => Promise<FinalVoucherV2ReservationReceipt>;
   /**
    * What `close()` does after posting the final voucher to `/tab/settle`:
    *  - 'revoke' (default, openTab): passkey-sign + submit the on-chain session
@@ -167,7 +169,7 @@ class TabImpl implements Tab {
    *  facilitator for on-chain settle without needing the seller to round-trip
    *  it back to us. Null if no voucher was signed in this tab's lifetime
    *  (close-without-stream → nothing to settle). */
-  private lastSignedVoucher: SignedVoucher | null = null;
+  private lastSignedVoucher: TabSignedVoucher | null = null;
   /** Exact economic increment bound to `lastSignedVoucher`. In Native Tab V2
    *  this is also the immutable reservation amount, and `/tab/settle` must
    *  send this value rather than reconstructing it from lifetime cumulative. */
@@ -176,7 +178,7 @@ class TabImpl implements Tab {
    *  immediately before the current one. Retained so `rollbackVoucher` can
    *  restore the pre-refusal voucher when a seller honestly refuses the
    *  most recent one. Set at commit time inside `signNextVoucher`. */
-  private previousSignedVoucher: SignedVoucher | null = null;
+  private previousSignedVoucher: TabSignedVoucher | null = null;
   /** Increment paired with `previousSignedVoucher`, retained for V1 rollback. */
   private previousSignedVoucherIncrementAtomic: bigint | null = null;
 
@@ -219,7 +221,7 @@ class TabImpl implements Tab {
    * The seller MUST verify before delivering. The SDK only protects the
    * buyer from over-signing (cap, expiry, perUnitCap).
    */
-  async signNextVoucher(incrementAtomic: AtomicAmount): Promise<SignedVoucher> {
+  async signNextVoucher(incrementAtomic: AtomicAmount): Promise<TabSignedVoucher> {
     this.beginOperation('voucher');
     try {
       return await this.signNextVoucherExclusive(incrementAtomic);
@@ -230,7 +232,7 @@ class TabImpl implements Tab {
 
   private async signNextVoucherExclusive(
     incrementAtomic: AtomicAmount,
-  ): Promise<SignedVoucher> {
+  ): Promise<TabSignedVoucher> {
     if (this.closed) throw new TabClosedError(this.channelId);
 
     const incBig = BigInt(incrementAtomic);
@@ -288,23 +290,28 @@ class TabImpl implements Tab {
     // the voucher can be returned to a merchant-facing caller. If it times
     // out, counters stay unchanged and the next retry reproduces the same
     // exact bytes for idempotent reconciliation.
+    let reservationReceipt: FinalVoucherV2ReservationReceipt | undefined;
     if (this.internals.beforeVoucherRelease) {
-      await this.internals.beforeVoucherRelease({
+      reservationReceipt = await this.internals.beforeVoucherRelease({
         voucher: signed,
         incrementAtomic: incBig.toString(),
         previousCumulativeAtomic: this.cumulativeAtomic.toString(),
       });
     }
 
+    const released: TabSignedVoucher = reservationReceipt
+      ? { ...signed, reservationReceipt }
+      : signed;
+
     // Commit: counters, one level of history, and the new last voucher.
     this.previousSignedVoucher = this.lastSignedVoucher;
     this.previousSignedVoucherIncrementAtomic =
       this.lastSignedVoucherIncrementAtomic;
-    this.lastSignedVoucher = signed;
+    this.lastSignedVoucher = released;
     this.lastSignedVoucherIncrementAtomic = incBig;
     this.sequenceNumber = nextSequence;
     this.cumulativeAtomic = newCumulative;
-    return signed;
+    return released;
   }
 
   private beginOperation(operation: 'voucher' | 'close' | 'rollback'): void {
@@ -531,18 +538,32 @@ function isContextBoundV2Session(session: SessionKey): boolean {
 
 /**
  * Serialize a signed voucher to the `X-Tab-Voucher` header value:
- * base64-encoded JSON with hex-encoded byte fields. This is THE wire
- * encoding the seller middleware and the facilitator's `/tab/settle`
- * endpoint both parse — `stream()` uses it, and `payAndFetch` uses it to
- * pay a `tab`-scheme accepts entry directly.
+ * base64-encoded JSON with hex-encoded byte fields. V2 additionally carries
+ * the complete reservation receipt that was independently verified before the
+ * voucher left the buyer. The receipt is an untrusted transaction locator at
+ * the seller; it never replaces the seller's own finalized chain proof.
+ *
+ * This is THE wire encoding the seller middleware and the facilitator's
+ * `/tab/settle` endpoint both parse — `stream()` uses it, and `payAndFetch`
+ * uses it to pay a `tab`-scheme accepts entry directly.
  */
-export function voucherToHeader(signed: SignedVoucher): string {
+export function voucherToHeader(
+  signed: SignedVoucher | TabSignedVoucher,
+  reservationReceipt?: FinalVoucherV2ReservationReceipt,
+): string {
+  const carriedReceipt = reservationReceipt
+    ?? (signed as TabSignedVoucher).reservationReceipt;
+  const isV2 = (signed.payload.sequenceNumber & 0x8000_0000) !== 0;
+  if (isV2 && !carriedReceipt) {
+    throw new Error('native_tab_v2_reservation_receipt_required');
+  }
   return Buffer.from(
     JSON.stringify({
       payload: signed.payload,
       sessionPublicKey: bytesToHex(signed.sessionPublicKey),
       sessionRegistration: bytesToHex(signed.sessionRegistration),
       sessionSignature: bytesToHex(signed.sessionSignature),
+      ...(carriedReceipt ? { reservationReceipt: carriedReceipt } : {}),
     }),
     'utf8',
   ).toString('base64');
@@ -897,6 +918,7 @@ export async function openTab(options: OpenTabOptions): Promise<Tab> {
       const receipt = await options.reserveFinalVoucherV2!(input);
       assertFinalVoucherV2ReservationReceipt(input, receipt);
       await options.vault.verifyFinalVoucherV2Reservation!(input, receipt);
+      return receipt;
     };
   }
 

--- a/src/tab/types.ts
+++ b/src/tab/types.ts
@@ -166,6 +166,19 @@ export interface FinalVoucherV2ReservationReceipt {
   economicEffectDigest?: string;
 }
 
+/**
+ * Voucher released by a live Tab handle. Historical V1 vouchers omit the
+ * receipt. Every V2 voucher carries the complete provider receipt that the
+ * buyer already verified before release; sellers still treat that receipt as
+ * untrusted evidence and independently prove its finalized transaction.
+ *
+ * This extends the existing SignedVoucher shape so existing callers that only
+ * consume the four signed fields remain source-compatible.
+ */
+export interface TabSignedVoucher extends SignedVoucher {
+  readonly reservationReceipt?: FinalVoucherV2ReservationReceipt;
+}
+
 export type ReserveFinalVoucherV2 = (
   input: FinalVoucherV2ReservationInput,
 ) => Promise<FinalVoucherV2ReservationReceipt>;
@@ -258,7 +271,7 @@ export interface Tab {
    * Same counter, same scope enforcement as stream() — throws
    * SessionScopeExceededError past the cap.
    */
-  signNextVoucher(incrementAtomic: AtomicAmount): Promise<SignedVoucher>;
+  signNextVoucher(incrementAtomic: AtomicAmount): Promise<TabSignedVoucher>;
 
   /**
    * Streamed paid request. Returns an async iterable of chunks. Voucher


### PR DESCRIPTION
## What changed

- Carries the complete `FinalVoucherV2ReservationReceipt` inside the existing `X-Tab-Voucher` envelope across `openTab`, `tabFromGrant`, `stream`, and `payAndFetch`.
- Makes Native Tab V2 seller admission fail closed when the proof is missing or malformed.
- Re-reads the exact SessionAccount PDA at finalized commitment for every V2 voucher, verifies account ownership, registration/wire version, the already-covered frontier, and exact `currentOutstanding` coverage.
- Reuses the Solana reservation verifier so the seller fetches the finalized locator transaction, recomputes the authority-signed Memo for the presented voucher, validates the exact settle instruction, and reads coherent post-state with `minContextSlot` anchored only to the fetched transaction slot.
- Preserves historical V1 cached behavior and the already-merged V2 terminal exact-increment settlement behavior.

## Why

The prior seller path could accept a V2 voucher from cached registration plus an equal outstanding amount without proving that the authoritative reservation transaction was bound to that exact voucher. A valid session-key holder could therefore substitute a different same-amount voucher. Confirmed-only or provider-asserted state was also too weak for irreversible seller delivery.

## Security and compatibility

- Provider-local lifecycle metadata remains non-authoritative. Economic authority comes from the finalized settle transaction, exact authority-signed Memo, and coherent finalized post-state.
- Missing, malformed, replayed, consumed, wrong-version, same-amount-substituted, or confirmed-only proofs fail before route delivery.
- V1 wire behavior remains unchanged.

## Validation

- `npm test`: 68 files, 589 tests passed
- `npm run typecheck`
- `npm run build`: ESM, CJS, and DTS passed
- `git diff --check`
- Rebased on `bd0c123`, including terminal exact `attemptedAmount` behavior from PR #51
