### PR TITLE
chore(release): 6.0.0-rc.1

### DIFF
--- a/.superstack/build-context.md
+++ b/.superstack/build-context.md
@@ -6,7 +6,7 @@
 |---|---|
 | Package | `@dexterai/x402` |
 | Architecture | TypeScript SDK with Solana Native Tab V2 |
-| Reviewed at | 2026-08-16T10:03:47Z |
+| Reviewed at | 2026-08-16T14:12:11Z |
 
 ## Source Status
 
@@ -15,7 +15,8 @@
 | Native Tab V2 source complete | Yes |
 | Root package install, typecheck, build, and tests | Yes |
 | Package artifact and clean consumer import/typecheck | Yes |
-| Committed and merged | No |
+| Security train committed and merged | Yes (`132baf4945d8bbcbd28475987ef35f1811e37149`) |
+| rc.1 release record merged | No; release PR pending |
 | Published | No |
 | Deployed and production-proven | No |
 
@@ -32,7 +33,8 @@
 - Binds each released V2 payment claim to its exact authority-signed Solana reservation transaction.
 - Releases claims only after finalized chain proof and coherent finalized account readback.
 - Preserves and reconciles the exact close transaction across ambiguous transport outcomes.
-- Uses Vault 0.43.1 exact-state V3 revocation and rejects stale or mismatched state.
+- Uses Vault 0.43.2 exact-state V3 revocation and rejects stale or mismatched state.
+- Keeps every documented ESM and CommonJS package entrypoint loadable; the server bundle no longer leaks its ESM-only sponsored-access runtime dependency into `require()` consumers.
 - Fails closed across V2 refusal, ambiguity, rollback, and concurrent signing paths.
 - Rejects unsupported V1 buyer opening in v6 while retaining seller verification of historical V1 claims.
 
@@ -40,11 +42,11 @@
 
 - Root clean install passed.
 - Typecheck and declaration build passed.
-- Full SDK suite: 563/563 passed.
-- Native Tab subset: 145/145 passed.
-- Dry package: 63 files; all ESM, CJS, and type export targets present.
-- Clean external ESM, CJS, and strict TypeScript consumer checks passed.
+- Full SDK suite: 589/589 passed across 68 files.
+- Dry package: 63 files, 346,328 bytes; deterministic SHA-256 `db3cad36726ac92ebad62c89e7ae0af8a526e45e86ab90850895765db0b393cd`.
+- Clean external ESM and CommonJS loads passed for every exported package path.
+- Strict NodeNext TypeScript consumer checks passed for V2 receipt transport, seller middleware, buyer routes, and the Solana verifier.
 
 ### Remaining release boundary
 
-The reviewed source is ready to commit. It is not yet merged, published, installed by maintained consumers, deployed, or proven by a fresh production purchase, settlement, and close. Standalone example locks must be regenerated against an actually published v6 package before those examples can be called current.
+The security train is merged. The rc.1 release record still must be committed, reviewed, merged, tagged, and published under `next`. The four maintained example locks are pinned to the exact deterministic tarball planned for publication, but must be regenerated from a fresh npm cache and verified against registry integrity after rc.1 becomes visible. Consumer deployment and fresh production acceptance remain separate, explicitly out-of-scope steps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.1] - 2026-08-16
+
+### Fixed
+
+- Native Tab V2 sellers now require the complete reservation receipt in the existing `X-Tab-Voucher` envelope and independently prove the exact finalized `settle_voucher` transaction plus its Dexter-authority-signed voucher-binding Memo before delivery. Missing, malformed, confirmed-only, replayed, consumed, wrong-version, stale-registration, and same-amount substituted proofs fail closed.
+- V2 seller admission re-reads the exact finalized SessionAccount PDA for every voucher and requires `currentOutstanding` to equal only the uncovered voucher increment above the authoritative settled/crystallized frontier.
+- V2 terminal settlement sends the exact final reservation increment as `attemptedAmount`, rather than reconstructing it from the tab's lifetime cumulative amount.
+- The CommonJS `@dexterai/x402/server` entrypoint now bundles the ESM-only sponsored-access runtime constant, so a clean `require()` consumer no longer fails during module loading.
+
+### Changed
+
+- The complete verified `FinalVoucherV2ReservationReceipt` now survives every buyer route (`openTab`, `tabFromGrant`, `stream`, and `payAndFetch`) inside the existing voucher envelope. Provider-local lifecycle metadata remains non-authoritative; finalized transaction, Memo, and coherent post-state evidence authorize seller delivery.
+- `@dexterai/vault` is pinned exactly to `0.43.2` for both peer and development use, including its corrected optional-account sentinel encoding.
+
 ## [6.0.0-rc.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Tabs are Solana. One-shot and batch settlement span Solana and the major EVM cha
 ## More
 
 - **[REFERENCE.md](./REFERENCE.md)** — every export, option table, and example: tabs, one-shot, batch settlement, discovery.
-- **Upgrading?** v6 pins the tested Vault `0.43.1` pair, requires voucher-bound V2 reservation receipts, and uses exact-state V3 revocation. Migration from v5/v4/v3: [REFERENCE.md](./REFERENCE.md#migration).
+- **Upgrading?** v6 pins the tested Vault `0.43.2` pair, requires voucher-bound V2 reservation receipts, and uses exact-state V3 revocation. Migration from v5/v4/v3: [REFERENCE.md](./REFERENCE.md#migration).
 - **License** — MIT, see [LICENSE](./LICENSE).
 
 ---

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -42,7 +42,7 @@ import { createSolanaAdapter, createEvmAdapter } from '@dexterai/x402/adapters';
 import { toAtomicUnits, fromAtomicUnits } from '@dexterai/x402/utils';
 ```
 
-> `@dexterai/vault` is an exact **peer dependency** at `0.43.1`: install it alongside the matching v6 x402 package so the adapter, revocation wire, and your app use one tested Vault contract.
+> `@dexterai/vault` is an exact **peer dependency** at `0.43.2`: install it alongside the matching v6 x402 package so the adapter, revocation wire, and your app use one tested Vault contract.
 
 ---
 
@@ -105,7 +105,7 @@ Builds the `vault` adapter the buyer calls drive through.
 | `passkeySigner` | `PasskeySignerWithPublicKey` | A `signOperation(operationMessage)` signer (see below) |
 | `feePayer` | `Signer` | Lamport fee payer |
 
-The `passkeySigner` uses Vault 0.43.1's canonical shape: `{ credentialId, publicKey, signOperation(operationMessage) }`. The adapter passes the raw operation bytes. The signer obtains the canonical V7 200-byte challenge binding the fixed program, exact vault, current monotonic authorization nonce, operation hash, and fresh ceremony entropy; the adapter owns only the precompile assembly. Do not substitute a bare `sha256(operationMessage)` challenge for V7 operations.
+The `passkeySigner` uses Vault 0.43.2's canonical shape: `{ credentialId, publicKey, signOperation(operationMessage) }`. The adapter passes the raw operation bytes. The signer obtains the canonical V7 200-byte challenge binding the fixed program, exact vault, current monotonic authorization nonce, operation hash, and fresh ceremony entropy; the adapter owns only the precompile assembly. Do not substitute a bare `sha256(operationMessage)` challenge for V7 operations.
 
 - **Browser:** vault's `DexterApiBrowserPasskeySigner` — drops in with no shim.
 - **CLI / server agent:** `passkeySignerFromP256Keypair(kp, { resolveAuthorizationContext })` from `@dexterai/x402/tab/adapters/solana`, wrapping a locally-held P-256 keypair. The resolver must read the current `PasskeyAuthorization` state immediately before a revoke ceremony; the helper never guesses that nonce.
@@ -178,6 +178,8 @@ app.get('/paid/tick',
 ```
 
 For a tab-only endpoint, compose the two middlewares directly: `tabChallengeMiddleware` (answers voucher-less requests with the standard x402 challenge, so any agent can discover you) before `tabMiddleware` (verifies the per-charge vouchers). Both are exported from `@dexterai/x402/tab/seller`.
+
+For Native Tab V2, the buyer carries the complete reservation receipt inside the same `X-Tab-Voucher` envelope. Seller middleware treats it only as an untrusted transaction locator: before your handler can deliver, it re-reads the exact SessionAccount PDA at finalized commitment, verifies the active registration and wire version, requires `currentOutstanding` to equal the voucher's uncovered increment, fetches the finalized reservation transaction, recomputes the Memo for the presented voucher, verifies the Dexter authority signature, and reads coherent post-state at or after that transaction's independently observed slot. A cached registration, equal amount, provider assertion, or confirmed-only transaction is not delivery authorization.
 
 How the protection works: as the agent spends, accrued charges crystallize on-chain into a reservation against the buyer's wallet — sized to exactly what's accrued, not the whole wallet — so the buyer can't withdraw out from under your charges. One on-chain settle at close pays your `sellerPubkey` for everything metered; you hold no key and sign nothing.
 
@@ -311,7 +313,7 @@ Endpoints paid through the facilitator are auto-discovered, named, and quality-t
 
 Two changes, both about packaging and the passkey signer — the payment path itself is unchanged.
 
-1. **`@dexterai/vault` became a peer dependency** in v5, rather than a bundled dependency. Current v6 consumers must use the exact tested `0.43.1` pair described above.
+1. **`@dexterai/vault` became a peer dependency** in v5, rather than a bundled dependency. Current v6 consumers must use the exact tested `0.43.2` pair described above.
 2. **The passkey signer contract is `signOperation(operationMessage)`**, replacing the old `sign(challenge)`. The adapter hands the signer the RAW operation message. A V7 signer must resolve the authoritative vault authorization nonce and build the canonical 200-byte challenge; bare `sha256(op)` is legacy-only and fails closed on V7. If you wrote a custom signer against `sign(challenge)`, pass the raw operation into Dexter's canonical challenge policy instead of accepting a caller-supplied challenge. Vault's browser signer and this package's `passkeySignerFromP256Keypair` node/agent signer already conform for the supported session operations.
 
 To pin the old surface, stay on `@dexterai/x402@^4`.

--- a/examples/live-chain/demo-app/package-lock.json
+++ b/examples/live-chain/demo-app/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@dexterai/live-chain-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@dexterai/vault": "0.43.1",
-        "@dexterai/x402": "6.0.0-rc.0",
+        "@dexterai/vault": "0.43.2",
+        "@dexterai/x402": "6.0.0-rc.1",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
         "dotenv": "^17.4.2"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@dexterai/vault": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.1.tgz",
-      "integrity": "sha512-wxABYBBKdfI7xoxoFBHL6CvjlCbq3Po2Nig6sJ1qsInk5iZhSNlYlAeBPCKXXjy5MzXGXt4InwbS8Mqpo+n/KA==",
+      "version": "0.43.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.2.tgz",
+      "integrity": "sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.0.tgz",
-      "integrity": "sha512-1GL/JYDQvVbELgH5mfaVLpV2QPogcPNNgPBsUvMI2NiFHfoWKDZ30R+No/bLzBwTwKuIL1oSJzZcQ5uxGRZcrg==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
+      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -78,7 +78,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dexterai/vault": "0.43.1",
+        "@dexterai/vault": "0.43.2",
         "@solana/wallet-adapter-base": "^0.9.0",
         "react": "^18.0.0 || ^19.0.0",
         "stripe": "^20.0.0",

--- a/examples/live-chain/demo-app/package.json
+++ b/examples/live-chain/demo-app/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dexterai/vault": "0.43.1",
-    "@dexterai/x402": "6.0.0-rc.0",
+    "@dexterai/vault": "0.43.2",
+    "@dexterai/x402": "6.0.0-rc.1",
     "@solana/web3.js": "^1.98.0",
     "bs58": "^6.0.0",
     "dotenv": "^17.4.2"

--- a/examples/live-chain/relay/package-lock.json
+++ b/examples/live-chain/relay/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@dexterai/live-chain-relay",
       "version": "0.1.0",
       "dependencies": {
-        "@dexterai/vault": "0.43.1",
-        "@dexterai/x402": "6.0.0-rc.0",
+        "@dexterai/vault": "0.43.2",
+        "@dexterai/x402": "6.0.0-rc.1",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
         "dotenv": "^17.4.2",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@dexterai/vault": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.1.tgz",
-      "integrity": "sha512-wxABYBBKdfI7xoxoFBHL6CvjlCbq3Po2Nig6sJ1qsInk5iZhSNlYlAeBPCKXXjy5MzXGXt4InwbS8Mqpo+n/KA==",
+      "version": "0.43.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.2.tgz",
+      "integrity": "sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.0.tgz",
-      "integrity": "sha512-1GL/JYDQvVbELgH5mfaVLpV2QPogcPNNgPBsUvMI2NiFHfoWKDZ30R+No/bLzBwTwKuIL1oSJzZcQ5uxGRZcrg==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
+      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -81,7 +81,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dexterai/vault": "0.43.1",
+        "@dexterai/vault": "0.43.2",
         "@solana/wallet-adapter-base": "^0.9.0",
         "react": "^18.0.0 || ^19.0.0",
         "stripe": "^20.0.0",

--- a/examples/live-chain/relay/package.json
+++ b/examples/live-chain/relay/package.json
@@ -11,8 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dexterai/vault": "0.43.1",
-    "@dexterai/x402": "6.0.0-rc.0",
+    "@dexterai/vault": "0.43.2",
+    "@dexterai/x402": "6.0.0-rc.1",
     "@solana/web3.js": "^1.98.0",
     "bs58": "^6.0.0",
     "dotenv": "^17.4.2",

--- a/examples/metered-inference/package-lock.json
+++ b/examples/metered-inference/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
-        "@dexterai/vault": "0.43.1",
-        "@dexterai/x402": "6.0.0-rc.0",
+        "@dexterai/vault": "0.43.2",
+        "@dexterai/x402": "6.0.0-rc.1",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
         "dotenv": "^17.4.2",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@dexterai/vault": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.1.tgz",
-      "integrity": "sha512-wxABYBBKdfI7xoxoFBHL6CvjlCbq3Po2Nig6sJ1qsInk5iZhSNlYlAeBPCKXXjy5MzXGXt4InwbS8Mqpo+n/KA==",
+      "version": "0.43.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.2.tgz",
+      "integrity": "sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.0.tgz",
-      "integrity": "sha512-1GL/JYDQvVbELgH5mfaVLpV2QPogcPNNgPBsUvMI2NiFHfoWKDZ30R+No/bLzBwTwKuIL1oSJzZcQ5uxGRZcrg==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
+      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -102,7 +102,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dexterai/vault": "0.43.1",
+        "@dexterai/vault": "0.43.2",
         "@solana/wallet-adapter-base": "^0.9.0",
         "react": "^18.0.0 || ^19.0.0",
         "stripe": "^20.0.0",

--- a/examples/metered-inference/package.json
+++ b/examples/metered-inference/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
-    "@dexterai/vault": "0.43.1",
-    "@dexterai/x402": "6.0.0-rc.0",
+    "@dexterai/vault": "0.43.2",
+    "@dexterai/x402": "6.0.0-rc.1",
     "@solana/web3.js": "^1.98.0",
     "bs58": "^6.0.0",
     "dotenv": "^17.4.2",

--- a/examples/push-per-send/package-lock.json
+++ b/examples/push-per-send/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@dexterai/example-push-per-send",
       "version": "0.1.0",
       "dependencies": {
-        "@dexterai/vault": "0.43.1",
-        "@dexterai/x402": "6.0.0-rc.0",
+        "@dexterai/vault": "0.43.2",
+        "@dexterai/x402": "6.0.0-rc.1",
         "@solana/web3.js": "^1.98.0",
         "dotenv": "^17.4.2",
         "express": "^5.1.0"
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@dexterai/vault": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.1.tgz",
-      "integrity": "sha512-wxABYBBKdfI7xoxoFBHL6CvjlCbq3Po2Nig6sJ1qsInk5iZhSNlYlAeBPCKXXjy5MzXGXt4InwbS8Mqpo+n/KA==",
+      "version": "0.43.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.2.tgz",
+      "integrity": "sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.9.7",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.0.tgz",
-      "integrity": "sha512-1GL/JYDQvVbELgH5mfaVLpV2QPogcPNNgPBsUvMI2NiFHfoWKDZ30R+No/bLzBwTwKuIL1oSJzZcQ5uxGRZcrg==",
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
+      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -79,7 +79,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dexterai/vault": "0.43.1",
+        "@dexterai/vault": "0.43.2",
         "@solana/wallet-adapter-base": "^0.9.0",
         "react": "^18.0.0 || ^19.0.0",
         "stripe": "^20.0.0",

--- a/examples/push-per-send/package.json
+++ b/examples/push-per-send/package.json
@@ -10,8 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dexterai/vault": "0.43.1",
-    "@dexterai/x402": "6.0.0-rc.0",
+    "@dexterai/vault": "0.43.2",
+    "@dexterai/x402": "6.0.0-rc.1",
     "@solana/web3.js": "^1.98.0",
     "dotenv": "^17.4.2",
     "express": "^5.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexterai/x402",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -22,7 +22,7 @@
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
-        "@dexterai/vault": "0.43.1",
+        "@dexterai/vault": "0.43.2",
         "@types/aws-lambda": "^8.10.161",
         "@types/express": "^5.0.6",
         "@types/node": "^22.10.0",
@@ -39,7 +39,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dexterai/vault": "0.43.1",
+        "@dexterai/vault": "0.43.2",
         "@solana/wallet-adapter-base": "^0.9.0",
         "react": "^18.0.0 || ^19.0.0",
         "stripe": "^20.0.0",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@dexterai/vault": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.1.tgz",
-      "integrity": "sha512-wxABYBBKdfI7xoxoFBHL6CvjlCbq3Po2Nig6sJ1qsInk5iZhSNlYlAeBPCKXXjy5MzXGXt4InwbS8Mqpo+n/KA==",
+      "version": "0.43.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.2.tgz",
+      "integrity": "sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "description": "Full-stack x402 SDK - add paid API monetization to any endpoint. Express middleware, React hooks, Access Pass, dynamic pricing. Solana, Base, Polygon, Arbitrum, Optimism, Avalanche, World Chain, Monad, Robinhood Chain, SKALE.",
   "author": "Dexter",
   "license": "MIT",
@@ -91,7 +91,7 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@dexterai/vault": "0.43.1",
+    "@dexterai/vault": "0.43.2",
     "@types/aws-lambda": "^8.10.161",
     "@types/express": "^5.0.6",
     "@types/node": "^22.10.0",
@@ -105,7 +105,7 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "@dexterai/vault": "0.43.1",
+    "@dexterai/vault": "0.43.2",
     "@solana/wallet-adapter-base": "^0.9.0",
     "react": "^18.0.0 || ^19.0.0",
     "stripe": "^20.0.0",

--- a/src/tab/__tests__/close-revoke-v3.test.ts
+++ b/src/tab/__tests__/close-revoke-v3.test.ts
@@ -137,7 +137,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('Solana adapter close — Vault 0.43.1 exact-state revocation', () => {
+describe('Solana adapter close — Vault 0.43.2 exact-state revocation', () => {
   it('signs the authoritative post-settlement snapshot and carries the exact pending count', async () => {
     const session = createSession();
     const snapshot = exactSnapshot(session);

--- a/src/tab/__tests__/register-instruction.test.ts
+++ b/src/tab/__tests__/register-instruction.test.ts
@@ -62,12 +62,12 @@ const buildIx = () =>
   });
 
 describe('buildAdapterRegisterInstruction (real vault builder)', () => {
-  test('builds against the vault program with the Vault 0.43.1 11-account list', () => {
+  test('builds against the vault program with the Vault 0.43.2 11-account list', () => {
     const ix = buildIx();
     expect(ix.programId.equals(DEXTER_VAULT_PROGRAM_ID)).toBe(true);
     // CANARY: if the vault program's register_session_key account list
     // changes again, this count (and the order checks below) must be
-    // revisited along with the adapter's arg construction. Vault 0.43.1 binds
+    // revisited along with the adapter's arg construction. Vault 0.43.2 binds
     // the permanent passkey guard, Swig/Vault identity, and graph config in
     // addition to the V6 session accounts (11 total with zero siblings).
     expect(ix.keys).toHaveLength(11);

--- a/src/tab/adapters/solana/index.ts
+++ b/src/tab/adapters/solana/index.ts
@@ -98,7 +98,7 @@ import type { TransactionInstruction } from '@solana/web3.js';
 
 // ── Passkey signer abstraction (unified with @dexterai/vault) ───────────
 //
-// The adapter consumes Vault 0.43.1's canonical signer shape: a 33-byte SEC1
+// The adapter consumes Vault 0.43.2's canonical signer shape: a 33-byte SEC1
 // publicKey + signOperation(operationMessage). Both paths conform — node via
 // passkeySignerFromP256Keypair, browser via vault's
 // DexterApiBrowserPasskeySigner — with NO bridge shim, sharing ONE vault

--- a/src/tab/adapters/solana/passkey-noble.ts
+++ b/src/tab/adapters/solana/passkey-noble.ts
@@ -181,7 +181,7 @@ export function signOperationWithPasskey(
  * assemble `precompileMessage` — that's x402-protocol assembly the adapter
  * rebuilds itself, identical on both the node and browser paths.
  *
- * `passkeySignerFromP256Keypair` wraps this with Vault 0.43.1's canonical
+ * `passkeySignerFromP256Keypair` wraps this with Vault 0.43.2's canonical
  * V7 challenge construction for supported session operations.
  */
 export function signChallenge(
@@ -208,7 +208,7 @@ export function signChallenge(
 }
 
 /**
- * Build a unified `PasskeySignerWithPublicKey` (Vault 0.43.1's canonical shape)
+ * Build a unified `PasskeySignerWithPublicKey` (Vault 0.43.2's canonical shape)
  * from a locally-held P-256 keypair — the node/CLI path. Returns
  * `{ credentialId, publicKey, signOperation(operationMessage) }`. The signer
  * owns canonical challenge construction for recognized V7 session operations,

--- a/src/tab/seller/verify.ts
+++ b/src/tab/seller/verify.ts
@@ -227,7 +227,7 @@ export async function verifyRegistrationOnChain(
     registration.allowedCounterparty,
     registration.programId,
   );
-  // Vault 0.43.1's fetchSessionAccount hardcodes `confirmed`. Do not use it
+  // Vault 0.43.2's fetchSessionAccount hardcodes `confirmed`. Do not use it
   // here: seller delivery is irreversible and V2 reservation admission must
   // be rooted in finalized state.
   const account = await connection.getAccountInfo(

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -36,4 +36,7 @@ export default defineConfig({
     '@x402/core',
     '@x402/evm',
   ],
+  // The ads-types package is ESM-only. Bundle its one runtime constant so the
+  // documented CommonJS server entrypoint remains require()-able.
+  noExternal: ['@dexterai/x402-ads-types'],
 });


### PR DESCRIPTION
## Summary

- release `@dexterai/x402` as `6.0.0-rc.1`
- pin the exact `@dexterai/vault@0.43.2` peer/dev pair in the root package and all four maintained examples
- document the complete Native Tab V2 reservation-receipt transport and seller-side finalized transaction/Memo/post-state admission proof merged in #52
- carry the exact terminal reservation increment and corrected Vault optional-account sentinel through the release references
- bundle the ESM-only sponsored-access runtime constant so the documented CommonJS server entrypoint remains loadable

## Verification

- clean `npm ci` with `@dexterai/vault@0.43.2`
- `npm run typecheck`
- `npm run build` including ESM, CJS, and declarations
- `npm test`: 68 files / 589 tests
- `git diff --check`
- two independent packs were byte-identical: 63 files, 346,328 bytes, SHA-256 `db3cad36726ac92ebad62c89e7ae0af8a526e45e86ab90850895765db0b393cd`, npm integrity `sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==`
- `npm publish --dry-run --access public --tag next` from that exact tarball
- clean external consumer passed every exported ESM and CJS package path plus strict NodeNext TypeScript imports for `TabSignedVoucher`, `FinalVoucherV2ReservationReceipt`, `openTab`, `tabFromGrant`, `payUrlWithTab`, `tabMiddleware`, and `verifySolanaFinalVoucherV2Reservation`
- all example locks structurally match the exact planned tarball and Vault 0.43.2; after registry publication they will be regenerated with a fresh npm cache, verified against registry integrity, and exercised with real clean installs/typechecks

## Release boundary

This PR does not publish, deploy consumers, or spend money. After merge, the exact merge commit will be tagged `v6.0.0-rc.1`; the exact verified tarball will be published under `next` only. `latest` must remain `5.4.2`, and rc.0 integrity/metadata must remain unchanged.
