### PR TITLE
chore(release): 6.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.2] - 2026-08-16
+
+### Fixed
+
+- Native Tab V2 buyer and seller admission now completes at Solana `confirmed` after independently fetching the exact successful reservation transaction, verifying its Dexter-authority-signed voucher-binding Memo, and reading coherent Vault/SessionAccount state anchored to that transaction slot. Paid requests no longer wait for finalization; processed-only evidence still fails closed.
+- V2 seller channel binding can no longer be poisoned by a scope-rejected first request, a concurrent competing registration, lease refusal, or a downstream durable-ledger failure.
+
+### Unchanged safety boundaries
+
+- Rollback, failed-transaction retirement, blockhash-expiry adjudication, close, and revoke retain their finalized/background boundaries. A later finalization preserves the already-issued confirmed receipt byte-for-byte.
+
 ## [6.0.0-rc.1] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexterai/x402",
-      "version": "6.0.0-rc.1",
+      "version": "6.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "description": "Full-stack x402 SDK - add paid API monetization to any endpoint. Express middleware, React hooks, Access Pass, dynamic pricing. Solana, Base, Polygon, Arbitrum, Optimism, Avalanche, World Chain, Monad, Robinhood Chain, SKALE.",
   "author": "Dexter",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- release the confirmed-latency Native Tab V2 admission changes as 6.0.0-rc.2
- document exact confirmed transaction and coherent post-state verification
- keep close, revoke, rollback, failure, and expiry adjudication on finalized/background boundaries

## Verification
- npm test: 68 files, 597 tests passed
- npm run typecheck
- npm run build (ESM, CJS, DTS)
- npm pack --dry-run --json
- git diff --check

## Publication
Publish only under the `next` dist-tag after this PR merges and the exact merge artifact is verified. `latest` remains 5.4.2.