### PR TITLE
docs: update examples to x402 rc2

### DIFF
--- a/examples/live-chain/demo-app/package-lock.json
+++ b/examples/live-chain/demo-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dexterai/vault": "0.43.2",
-        "@dexterai/x402": "6.0.0-rc.1",
+        "@dexterai/x402": "6.0.0-rc.2",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
         "dotenv": "^17.4.2"
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
-      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.2.tgz",
+      "integrity": "sha512-JnLDEC6pAf6UIV2vaXtIPT5LcEyzKvfwGopZGjVFIzs8LBwG1wgvxQ+hD4K5WRhMryUkPPr4EUN0TasIFs9krQ==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/examples/live-chain/demo-app/package.json
+++ b/examples/live-chain/demo-app/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@dexterai/vault": "0.43.2",
-    "@dexterai/x402": "6.0.0-rc.1",
+    "@dexterai/x402": "6.0.0-rc.2",
     "@solana/web3.js": "^1.98.0",
     "bs58": "^6.0.0",
     "dotenv": "^17.4.2"

--- a/examples/live-chain/relay/package-lock.json
+++ b/examples/live-chain/relay/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dexterai/vault": "0.43.2",
-        "@dexterai/x402": "6.0.0-rc.1",
+        "@dexterai/x402": "6.0.0-rc.2",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
         "dotenv": "^17.4.2",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
-      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.2.tgz",
+      "integrity": "sha512-JnLDEC6pAf6UIV2vaXtIPT5LcEyzKvfwGopZGjVFIzs8LBwG1wgvxQ+hD4K5WRhMryUkPPr4EUN0TasIFs9krQ==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/examples/live-chain/relay/package.json
+++ b/examples/live-chain/relay/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@dexterai/vault": "0.43.2",
-    "@dexterai/x402": "6.0.0-rc.1",
+    "@dexterai/x402": "6.0.0-rc.2",
     "@solana/web3.js": "^1.98.0",
     "bs58": "^6.0.0",
     "dotenv": "^17.4.2",

--- a/examples/metered-inference/package-lock.json
+++ b/examples/metered-inference/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@dexterai/vault": "0.43.2",
-        "@dexterai/x402": "6.0.0-rc.1",
+        "@dexterai/x402": "6.0.0-rc.2",
         "@solana/web3.js": "^1.98.0",
         "bs58": "^6.0.0",
         "dotenv": "^17.4.2",
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
-      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.2.tgz",
+      "integrity": "sha512-JnLDEC6pAf6UIV2vaXtIPT5LcEyzKvfwGopZGjVFIzs8LBwG1wgvxQ+hD4K5WRhMryUkPPr4EUN0TasIFs9krQ==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/examples/metered-inference/package.json
+++ b/examples/metered-inference/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
     "@dexterai/vault": "0.43.2",
-    "@dexterai/x402": "6.0.0-rc.1",
+    "@dexterai/x402": "6.0.0-rc.2",
     "@solana/web3.js": "^1.98.0",
     "bs58": "^6.0.0",
     "dotenv": "^17.4.2",

--- a/examples/push-per-send/package-lock.json
+++ b/examples/push-per-send/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dexterai/vault": "0.43.2",
-        "@dexterai/x402": "6.0.0-rc.1",
+        "@dexterai/x402": "6.0.0-rc.2",
         "@solana/web3.js": "^1.98.0",
         "dotenv": "^17.4.2",
         "express": "^5.1.0"
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@dexterai/x402": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.1.tgz",
-      "integrity": "sha512-ysnsLz33sK+LaRgpCfUC9WX7dHg9DGuiIT08+zKU4dzUHzxkBXG6G6hGG1mHkgaGYPa2tmqj8BXTmoq3CjGrlg==",
+      "version": "6.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dexterai/x402/-/x402-6.0.0-rc.2.tgz",
+      "integrity": "sha512-JnLDEC6pAf6UIV2vaXtIPT5LcEyzKvfwGopZGjVFIzs8LBwG1wgvxQ+hD4K5WRhMryUkPPr4EUN0TasIFs9krQ==",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/examples/push-per-send/package.json
+++ b/examples/push-per-send/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dexterai/vault": "0.43.2",
-    "@dexterai/x402": "6.0.0-rc.1",
+    "@dexterai/x402": "6.0.0-rc.2",
     "@solana/web3.js": "^1.98.0",
     "dotenv": "^17.4.2",
     "express": "^5.1.0"


### PR DESCRIPTION
## Summary
- pin all four maintained Native Tab examples to @dexterai/x402 6.0.0-rc.2
- regenerate each standalone lock against the public registry artifact

## Verification
- npm ci and npm run typecheck in push-per-send
- npm ci and npm run typecheck in metered-inference
- npm ci and npm run typecheck in live-chain/demo-app
- npm ci and npm run typecheck in live-chain/relay
- git diff --check