### PR TITLE
feat: make seller Tab delivery state durable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 .env
 .env.local
 coverage/
+.tab-ledger/
 
 test-wallet-base.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Seller-owned delivery accounting is now restart- and takeover-safe. Every
+  channel lease carries an unguessable owner token plus a monotonically
+  increasing fence, and every ledger write, delete, renewal, and release is
+  conditional on that exact lease generation. The SSE meter writes each
+  charge to the fenced durable ledger before the corresponding service may be
+  sent; a crash can conservatively over-account an unsent unit, but cannot
+  erase delivered service and re-grant the same signed budget after restart.
+- `RedisChannelLedger` declares explicit restart/multi-instance capabilities,
+  performs authoritative reads on the Redis primary, renews live leases, and
+  fails closed on store or lease loss. Its `restartSafe` capability requires
+  both the exact AOF-always/no-data-loss/noeviction/dedicated-instance
+  durability attestation and
+  `writerCutover: 'all-legacy-writers-stopped'`.
+
+### Changed
+
+- Seller admission revalidates the current durable voucher registration,
+  cumulative amount, and reservation proof after acquiring the channel lease.
+  Delayed requests therefore cannot overwrite a newer process's accepted
+  state. A response that disconnects during proof work cannot later acquire or
+  indefinitely renew a lease.
+- Channel IDs are canonical lowercase 64-character hex at seller admission.
+  Every bundled ledger adapter also rejects noncanonical IDs before acquiring
+  a lock or touching storage, so direct adapter calls cannot recreate aliases.
+- `ledgerSafetyMode` must be explicit unless `NODE_ENV` is exactly `test` or
+  `development`. `production-single-instance` requires durable restart-safe
+  state plus the explicit channel-alias cutover; `production-multi-instance`
+  additionally requires cross-process atomic fencing. There is no production
+  fallback to memory or inferred single-process topology.
+
+### Breaking
+
+- Custom `ChannelLedger` adapters must expose `capabilities`, use the new
+  `ChannelLease { ownerToken, fence, heldUntilUnixMs }`, accept that lease on
+  every `set`, `update`, and `delete`, and implement conditional
+  `tryAcquireLease`, `renewLease`, and `releaseLease`. Adapters must reject
+  stale owner/fence mutations instead of silently applying them, reject every
+  non-lowercase/non-64-hex channel ID before locking or storage access, and
+  declare `canonicalChannelIds` only after historical aliases are migrated or
+  the durable store is proven empty.
+- `SseMeter.charge()` is asynchronous write-ahead accounting and must be
+  awaited before `send()`. Concurrent charges are serialized against the
+  signed cap; `send()` fails while a charge commit is pending.
+
+### Seller-ledger upgrade and Redis keyspace migration
+
+- **Canonical channel-ID cutover is mandatory for every durable adapter.** The
+  voucher signature covers the decoded 32 channel bytes, so historical SDKs
+  could persist the same signed channel under multiple case spellings. Before
+  setting `channelIdCutover: 'legacy-case-aliases-migrated-or-empty'`, stop all
+  seller writers and enumerate every ledger, lease, and fence key/file. Group
+  records by lowercase channel ID; wait for and remove every alias lease;
+  require exact session/public-key/registration compatibility (otherwise
+  quarantine the entire group for manual review); retain the highest valid
+  signed voucher by cumulative then sequence; **sum** delivered cumulative
+  across distinct aliases; take the maximum crystallized and gate-refused
+  watermarks; and publish the lowercase fence at least one greater than the
+  maximum alias fence. Overcounting a copied duplicate is safer than re-granting
+  delivered service. Verify the canonical record before deleting every alias
+  ledger/lease/fence. A brand-new proven-empty store may acknowledge the same
+  cutover without migration. Production middleware refuses File, Redis, or a
+  custom adapter until `canonicalChannelIds` attests this invariant.
+
+- The default Redis layout remains `legacy-v0` (`<prefix>ledger:<channelId>`,
+  `<prefix>lease:<channelId>`, `<prefix>fence:<channelId>`) so upgrading does
+  not hide existing ledger state or split leases during rollout. Before
+  asserting `writerCutover`, stop every pre-fencing seller process. A raw UUID
+  lease written by an older process is respected until it expires; the new
+  writer never renews or releases that foreign lease.
+- `cluster-v1` is opt-in and never supports a rolling mixed-layout deploy. Stop
+  all seller writers; wait for every legacy lease to expire; copy every legacy
+  canonical lowercase ledger record and fence counter to the corresponding hash-tagged
+  `<prefix>{<channelId>}:ledger|fence` keys (preserving or increasing each
+  fence); verify the copies; then remove all legacy ledger, lease, and fence
+  keys. Only after that stop-the-world procedure may the service start with
+  `keyLayout: 'cluster-v1'`,
+  `keyspaceCutover: 'legacy-state-migrated-or-empty'`, the writer cutover, and
+  the channel-ID cutover acknowledgements. Runtime admission rejects any
+  legacy ledger, lease, or fence remnant rather than treating the new keyspace
+  as empty.
+
 ## [6.0.0-rc.2] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -115,19 +115,50 @@ That `vault` drives [the tab loop above](#the-tab). To inspect a seller's price 
 You get paid for exactly what you serve, and you hold no key. As an agent spends against its tab, charges crystallize on-chain into a reservation against the buyer's wallet; one settle at close pays your address for everything metered. One middleware advertises both a tab and a one-shot price in a single `402`, so tab-native agents and one-shot callers pay at the same rate.
 
 ```ts
-import { tabOrExactMiddleware, requireTab, openSse } from '@dexterai/x402/tab/seller';
+import {
+  FileChannelLedger,
+  tabOrExactMiddleware,
+  requireTab,
+  openSse,
+} from '@dexterai/x402/tab/seller';
 import type { X402Request } from '@dexterai/x402/server';
 
+const ledgerDir = process.env.TAB_LEDGER_DIR;
+const channelIdCutover = process.env.TAB_CHANNEL_ID_CUTOVER;
+if (!ledgerDir) throw new Error('TAB_LEDGER_DIR must name persistent storage');
+if (channelIdCutover !== 'legacy-case-aliases-migrated-or-empty') {
+  throw new Error('prove the seller ledger empty or complete the documented alias migration first');
+}
+const ledger = new FileChannelLedger(ledgerDir, { channelIdCutover });
+
 app.get('/paid/tick',
-  tabOrExactMiddleware({ connection, sellerPubkey, network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', perUnit: '0.01' }),
+  tabOrExactMiddleware({
+    connection,
+    sellerPubkey,
+    network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    perUnit: '0.01',
+    ledger,
+    ledgerSafetyMode: 'production-single-instance',
+  }),
   async (req, res) => {
     if ((req as X402Request).x402) { res.json({ data: '...' }); return; }   // one-shot caller, already paid
     const meter = openSse(res, { tab: requireTab(req), perUnit: '0.01' });  // tab caller
     await meter.charge(1);                  // demand a fresh voucher; throws if the cap is exceeded
     meter.send(JSON.stringify({ data: '...' }));
-    await meter.end();                      // always await — persists the final delivered amount
+    await meter.end();                      // always await — closes the metered response
   });
 ```
+
+`FileChannelLedger` is restart-safe for one seller process; keep its directory
+on persistent storage. `TAB_CHANNEL_ID_CUTOVER` is an operator assertion, never
+a copy/paste default: set it only for a proven-empty store or after completing
+the mixed-case alias merge in
+[CHANGELOG.md](./CHANGELOG.md#seller-ledger-upgrade-and-redis-keyspace-migration).
+Multiple replicas must use `RedisChannelLedger` with
+`ledgerSafetyMode: 'production-multi-instance'`, verified durability, and the
+documented writer/keyspace cutovers. Production configuration is explicit; the
+in-memory default is accepted only in exact `test` or `development`
+environments.
 
 Want a tab-only endpoint, or to compose the pieces yourself? The full seller surface is in [REFERENCE.md](./REFERENCE.md#sellers).
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -162,20 +162,84 @@ The Vault instruction proves the exact session and amount. The immediately follo
 `tabOrExactMiddleware` is the recommended default: one middleware that advertises a tab and a one-shot price in a single 402 challenge, so agents pay by tab and one-shot callers pay exact, at the same price.
 
 ```ts
-import { tabOrExactMiddleware, requireTab, openSse } from '@dexterai/x402/tab/seller';
+import {
+  FileChannelLedger,
+  tabOrExactMiddleware,
+  requireTab,
+  openSse,
+} from '@dexterai/x402/tab/seller';
 import type { X402Request } from '@dexterai/x402/server';
 
+const ledgerDir = process.env.TAB_LEDGER_DIR;
+const channelIdCutover = process.env.TAB_CHANNEL_ID_CUTOVER;
+if (!ledgerDir) throw new Error('TAB_LEDGER_DIR must name persistent storage');
+if (channelIdCutover !== 'legacy-case-aliases-migrated-or-empty') {
+  throw new Error('prove the seller ledger empty or complete the documented alias migration first');
+}
+const ledger = new FileChannelLedger(ledgerDir, { channelIdCutover });
+
 app.get('/paid/tick',
-  tabOrExactMiddleware({ connection, sellerPubkey, network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', perUnit: '0.01' }),
+  tabOrExactMiddleware({
+    connection,
+    sellerPubkey,
+    network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    perUnit: '0.01',
+    ledger,
+    ledgerSafetyMode: 'production-single-instance',
+  }),
   async (req, res) => {
     if ((req as X402Request).x402) { res.json({ data: '...', paidVia: 'exact' }); return; } // exact rail
     const tab = requireTab(req);                                                            // tab rail
     const meter = openSse(res, { tab, perUnit: '0.01' });
     await meter.charge(1);                  // demand a fresh voucher; throws if the cap is exceeded
     meter.send(JSON.stringify({ data: '...' }));
-    await meter.end();                      // ALWAYS await — persists the final delivered amount
+    await meter.end();                      // ALWAYS await — closes the metered response
   });
 ```
+
+`FileChannelLedger` is restart-safe for exactly one seller process and its
+directory must live on persistent storage. `channelIdCutover` is an operator
+assertion supplied through `TAB_CHANNEL_ID_CUTOVER`, not an automatic or
+copy/paste default: use it immediately only for a
+proven-empty store, or after the changelog's case-alias merge. Multiple replicas
+require `RedisChannelLedger`, `production-multi-instance`, exact durability and
+writer/channel/keyspace cutover attestations.
+Outside exact `NODE_ENV=test` or `development`, `ledgerSafetyMode` is required;
+there is no silent production fallback to memory or a topology guess.
+
+For a replicated seller, use a fail-fast Redis client configured for primary
+reads and pass the exact operational attestations only after verifying them:
+
+```ts
+import { RedisChannelLedger } from '@dexterai/x402/tab/seller';
+
+const writerCutover = process.env.TAB_WRITER_CUTOVER;
+const channelIdCutover = process.env.TAB_CHANNEL_ID_CUTOVER;
+if (writerCutover !== 'all-legacy-writers-stopped') {
+  throw new Error('stop and verify every pre-fencing seller writer first');
+}
+if (channelIdCutover !== 'legacy-case-aliases-migrated-or-empty') {
+  throw new Error('prove the Redis store empty or complete the documented alias migration first');
+}
+const ledger = new RedisChannelLedger(redis, {
+  keyPrefix: 'tab:',
+  durability: {
+    persistence: 'aof-always',
+    failover: 'no-data-loss',
+    maxmemoryPolicy: 'noeviction',
+    isolation: 'dedicated-instance',
+  },
+  writerCutover,
+  channelIdCutover,
+});
+```
+
+The default `legacy-v0` layout preserves existing Redis ledger and lease keys.
+Do not select `cluster-v1` during a rolling deploy: first complete the
+stop-the-world ledger/fence copy and legacy-key removal procedure in
+[CHANGELOG.md](./CHANGELOG.md#seller-ledger-upgrade-and-redis-keyspace-migration), then add
+`keyLayout: 'cluster-v1'` and
+`keyspaceCutover: 'legacy-state-migrated-or-empty'`.
 
 For a tab-only endpoint, compose the two middlewares directly: `tabChallengeMiddleware` (answers voucher-less requests with the standard x402 challenge, so any agent can discover you) before `tabMiddleware` (verifies the per-charge vouchers). Both are exported from `@dexterai/x402/tab/seller`.
 

--- a/examples/live-chain/relay/.env.example
+++ b/examples/live-chain/relay/.env.example
@@ -16,6 +16,13 @@ SELLER_PRIVATE_KEY=
 # Port for the HTTP/SSE relay.
 PORT=4400
 
+# Seller-owned durable tab state. Mount this directory on persistent storage.
+# This relay config is single-process; use RedisChannelLedger for replicas.
+TAB_LEDGER_DIR=.tab-ledger
+# Set only for a brand-new/empty directory or after completing the changelog's
+# legacy mixed-case channel-key migration.
+TAB_CHANNEL_ID_CUTOVER=
+
 # Voucher cadence defaults. The relay uses these unless the buyer overrides
 # via openTab options.
 VOUCHER_BATCH_EVENTS=10

--- a/examples/live-chain/relay/.gitignore
+++ b/examples/live-chain/relay/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 *.log
+.tab-ledger/

--- a/examples/live-chain/relay/README.md
+++ b/examples/live-chain/relay/README.md
@@ -38,3 +38,10 @@ curl http://localhost:4400/healthz
 - The `SELLER_PRIVATE_KEY` is just an identity (the public key ends up as `allowed_counterparty` in the buyer's session scope). It doesn't pay gas or hold funds — the facilitator pays settlement gas, vouchers settle from the buyer's vault. Generate a fresh Ed25519 keypair for the demo.
 - The relay subscribes to `mainnet.helius-rpc.com` (NOT the legacy `rpc.helius.xyz` which returns 429 on websockets).
 - The seller middleware does ONE on-chain RPC per session at first-voucher time (verifying the registration matches the vault's on-chain passkey). All subsequent vouchers verify in-memory. The amortized cost per voucher is dominated by ed25519 signature verification, which is cheap.
+- The relay stores seller delivery truth in `TAB_LEDGER_DIR` through
+  `FileChannelLedger`; mount it on persistent storage and run exactly one relay
+  process. Set `TAB_CHANNEL_ID_CUTOVER` only for a proven-empty directory or
+  after the changelog's legacy case-alias merge. Replicated deployments must
+  replace it with `RedisChannelLedger`,
+  select `production-multi-instance`, and complete the SDK's explicit
+  durability, writer-generation, and keyspace cutover gates.

--- a/examples/live-chain/relay/src/index.ts
+++ b/examples/live-chain/relay/src/index.ts
@@ -23,6 +23,7 @@ import { Connection, Keypair, PublicKey } from '@solana/web3.js';
 import bs58 from 'bs58';
 
 import {
+  FileChannelLedger,
   tabMiddleware,
   requireTab,
   openSse,
@@ -38,6 +39,16 @@ const SELLER_PRIVATE_KEY = required('SELLER_PRIVATE_KEY');
 const PORT = Number(process.env.PORT ?? 4400);
 const EVENT_PRICE_USDC = process.env.EVENT_PRICE_USDC ?? '0.0001';
 const MAX_TAB_USDC = process.env.MAX_TAB_USDC ?? '5.00';
+const TAB_LEDGER_DIR = process.env.TAB_LEDGER_DIR ?? '.tab-ledger';
+function requireChannelIdCutover(): 'legacy-case-aliases-migrated-or-empty' {
+  if (process.env.TAB_CHANNEL_ID_CUTOVER !== 'legacy-case-aliases-migrated-or-empty') {
+    throw new Error(
+      'Set TAB_CHANNEL_ID_CUTOVER=legacy-case-aliases-migrated-or-empty only after ' +
+        'the seller ledger is empty or the documented legacy case-alias migration is complete',
+    );
+  }
+  return process.env.TAB_CHANNEL_ID_CUTOVER;
+}
 
 function required(name: string): string {
   const v = process.env[name];
@@ -49,6 +60,9 @@ function required(name: string): string {
 
 const seller = Keypair.fromSecretKey(bs58.decode(SELLER_PRIVATE_KEY));
 const connection = new Connection(SOLANA_RPC_URL, 'confirmed');
+const ledger = new FileChannelLedger(TAB_LEDGER_DIR, {
+  channelIdCutover: requireChannelIdCutover(),
+});
 const mux = new LaserstreamMux(
   // Helius Laserstream endpoint (mainnet).
   'https://laserstream-mainnet.helius-rpc.com',
@@ -75,6 +89,8 @@ const sellerMiddleware = tabMiddleware({
   network: 'solana:mainnet',
   perUnit: EVENT_PRICE_USDC,
   settle: 'on-close',
+  ledger,
+  ledgerSafetyMode: 'production-single-instance',
 });
 
 app.get('/stream/:account', sellerMiddleware, async (req: Request, res: Response) => {

--- a/examples/metered-inference/.env.example
+++ b/examples/metered-inference/.env.example
@@ -29,6 +29,13 @@ ANTHROPIC_API_KEY=
 # Optional. HTTP port (default 4021).
 #PORT=4021
 
+# Seller-owned durable tab state. Mount this directory on persistent storage.
+# This example runs one process; use RedisChannelLedger for multiple replicas.
+#TAB_LEDGER_DIR=.tab-ledger
+# Set only for a brand-new/empty directory or after completing the changelog's
+# legacy mixed-case channel-key migration.
+#TAB_CHANNEL_ID_CUTOVER=legacy-case-aliases-migrated-or-empty
+
 # ── Buyer snippet ────────────────────────────────────────────────────────────
 
 # Where the server runs (default http://localhost:4021).

--- a/examples/metered-inference/README.md
+++ b/examples/metered-inference/README.md
@@ -129,11 +129,12 @@ parse-guarded buyer. Base64's alphabet has no backslash and no newline, so
 frames cross the meter byte-identical. The codec lives in `sse-frame.ts`;
 `npm run check:frames` proves both the corruption and the fix mechanically.
 
-If the buyer's voucher budget runs out mid-stream, `charge()` throws, the SDK
-has already persisted what WAS delivered (`recordDelivered` fires on every
-terminal path, including client disconnect), and the buyer settles the
-delivered amount at close. A buyer cannot consume tokens it didn't sign for; a
-seller cannot bill tokens it didn't serve.
+If the buyer's voucher budget runs out mid-stream, `charge()` throws. Each
+successful charge was already fenced into durable seller state before its SSE
+token was sent, so disconnect or process death cannot re-grant the same signed
+budget after restart. The conservative crash ambiguity is one charged unit
+that may not have reached the socket; service is never sent before accounting.
+A buyer cannot consume tokens it didn't sign for.
 
 ## What the seller needs (and doesn't)
 
@@ -147,11 +148,19 @@ seller cannot bill tokens it didn't serve.
 - **Do not tune `lockCadence`.** It is deliberately unset in this example: as
   of `@dexterai/x402@5.3.1` the facilitator owns crystallization cadence
   server-side. It is a risk dial, not a performance dial — ship without it.
-- **Durability:** `tabOrExactMiddleware` uses the in-memory channel ledger, so
-  delivered-counters reset on restart (buyer-signed vouchers remain the source
-  of truth for settlement — you can't lose money, only re-grant unspent
-  budget). For a production seller, compose `tabChallengeMiddleware` +
-  `tabMiddleware({ ledger: new FileChannelLedger(dir), ... })`.
+- **Durability:** this server uses `FileChannelLedger` with
+  `ledgerSafetyMode: 'production-single-instance'`; mount `TAB_LEDGER_DIR` on
+  persistent storage, run exactly one process, and set
+  `TAB_CHANNEL_ID_CUTOVER` only after proving the directory empty or completing
+  the changelog's legacy case-alias merge. Multiple replicas must use
+  `RedisChannelLedger` with `production-multi-instance`, the exact verified
+  AOF/no-loss/noeviction/dedicated-instance attestation, and
+  `writerCutover: 'all-legacy-writers-stopped'` after actually stopping every
+  pre-fencing writer plus the channel-ID cutover. A `cluster-v1` key layout
+  additionally requires the documented stop-the-world legacy keyspace
+  migration.
+  Every write/release is fenced by owner token + monotonic fence; a crashed
+  pre-takeover process cannot overwrite the new owner's delivered counters.
 
 ## How you observe that you were paid
 

--- a/examples/metered-inference/server.ts
+++ b/examples/metered-inference/server.ts
@@ -43,7 +43,12 @@ import type { Request, Response } from 'express';
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
 import { Connection } from '@solana/web3.js';
-import { tabOrExactMiddleware, requireTab, openSse } from '@dexterai/x402/tab/seller';
+import {
+  FileChannelLedger,
+  tabOrExactMiddleware,
+  requireTab,
+  openSse,
+} from '@dexterai/x402/tab/seller';
 import type { X402Request } from '@dexterai/x402/server';
 import { encodeFrame } from './sse-frame.js';
 
@@ -73,6 +78,16 @@ const STICKER_HUMAN = microsToHuman(STICKER_MICROS); // '0.010000'
 // Receive-only payout pubkey. No key material anywhere in this process.
 const SELLER_PUBKEY = process.env.SELLER_PUBKEY ?? 'FKF63wLt122SLDNPBfpDgrMcQzxtdLfLyrUS1KziRR1h';
 const PORT = Number(process.env.PORT ?? 4021);
+const TAB_LEDGER_DIR = process.env.TAB_LEDGER_DIR ?? '.tab-ledger';
+function requireChannelIdCutover(): 'legacy-case-aliases-migrated-or-empty' {
+  if (process.env.TAB_CHANNEL_ID_CUTOVER !== 'legacy-case-aliases-migrated-or-empty') {
+    throw new Error(
+      'Set TAB_CHANNEL_ID_CUTOVER=legacy-case-aliases-migrated-or-empty only after ' +
+        'the seller ledger is empty or the documented legacy case-alias migration is complete',
+    );
+  }
+  return process.env.TAB_CHANNEL_ID_CUTOVER;
+}
 // One RPC read per buyer session (registration verify); never on the 402 path.
 const RPC_URL =
   process.env.HELIUS_RPC_URL ??
@@ -185,6 +200,9 @@ if (process.argv.includes('--selftest')) {
 // ── Payment middleware — the ONLY payment middleware on the route ────────────
 
 const connection = new Connection(RPC_URL, 'confirmed');
+const ledger = new FileChannelLedger(TAB_LEDGER_DIR, {
+  channelIdCutover: requireChannelIdCutover(),
+});
 
 const paywall = tabOrExactMiddleware({
   connection,
@@ -194,6 +212,8 @@ const paywall = tabOrExactMiddleware({
   // exact rail charges flat). The tab rail's per-token bill is set on openSse
   // in the handler below.
   perUnit: STICKER_HUMAN,
+  ledger,
+  ledgerSafetyMode: 'production-single-instance',
   description: `Metered Claude inference: ${PER_TOKEN_HUMAN} USDC per output token (tab) or ${STICKER_HUMAN} flat for up to ${MAX_OUTPUT_TOKENS} tokens (exact)`,
   // facilitatorUrl omitted -> https://x402.dexter.cash
   // lockCadence omitted -> facilitator-owned crystallization cadence (do not tune)
@@ -331,10 +351,9 @@ app.post('/v1/complete', express.json(), validateBody, paywall, async (req, res)
       await meter.end();
     } catch (streamErr) {
       // charge() throws ScopeViolationError when the buyer's voucher budget is
-      // exhausted mid-stream; the meter has already persisted what WAS
-      // delivered (recordDelivered fires on every terminal path). SSE headers
-      // are out, so just close the stream — the buyer settles the delivered
-      // amount at tab close.
+      // exhausted mid-stream; every successful charge was persisted before
+      // its send. SSE headers are out, so just close the stream — the buyer
+      // settles the durably accounted amount at tab close.
       console.error('[metered-inference] stream terminated:', (streamErr as Error).message);
       if (!res.writableEnded) res.end();
     }

--- a/examples/push-per-send/.env.example
+++ b/examples/push-per-send/.env.example
@@ -1,6 +1,13 @@
 # ── Server ───────────────────────────────────────────────────────────────────
 PORT=4880
 
+# Seller-owned durable tab state. Mount this directory on persistent storage.
+# This example runs one process; use RedisChannelLedger for multiple replicas.
+TAB_LEDGER_DIR=.tab-ledger
+# Set only for a brand-new/empty directory or after completing the changelog's
+# legacy mixed-case channel-key migration.
+TAB_CHANNEL_ID_CUTOVER=
+
 # Any Solana mainnet RPC. Used once per tab session, never per send.
 # Use a real provider (Helius etc.) in production.
 SOLANA_RPC_ENDPOINT=https://api.mainnet-beta.solana.com

--- a/examples/push-per-send/README.md
+++ b/examples/push-per-send/README.md
@@ -124,10 +124,17 @@ sticker honest for one-shot buyers.
 - **Do not set `lockCadence`.** It is omitted here on purpose: the facilitator
   owns crystallization cadence server-side as of 5.3.1. It is a risk dial, not
   a performance dial. Ship without it.
-- `tabOrExactMiddleware` keeps per-channel accounting in process memory. A
-  restart mid-tab is safe for funds (vouchers are verified on-chain
-  state + signatures) but forgets accrual counters; for durable, multi-instance
-  setups see `ChannelLedger` in the seller docs
+- This server uses `FileChannelLedger` + `production-single-instance`; mount
+  `TAB_LEDGER_DIR` on persistent storage and run exactly one process. Multiple
+  Set `TAB_CHANNEL_ID_CUTOVER` only for a proven-empty directory or after the
+  changelog's legacy case-alias merge. Multiple replicas require
+  `RedisChannelLedger` + `production-multi-instance`, its
+  exact durability attestation, and
+  `writerCutover: 'all-legacy-writers-stopped'`, and the channel-ID cutover. A
+  `cluster-v1` layout also requires the documented stop-the-world legacy
+  keyspace migration.
+  Owner-token/monotonic fences reject stale writes after crash takeover. See
+  `ChannelLedger` in the seller docs
   (https://docs.dexter.cash/docs/get-paid/sell-with-tabs).
 - Knowing you were paid: `tab.cumulative()` / receipts are **accrual**
   counters, not settlement confirmations. Settlement happens at tab close (the

--- a/examples/push-per-send/server.ts
+++ b/examples/push-per-send/server.ts
@@ -25,6 +25,7 @@ import express from 'express';
 import type { NextFunction, Request, Response } from 'express';
 import { Connection } from '@solana/web3.js';
 import {
+  FileChannelLedger,
   TAB_VOUCHER_HEADER,
   openSse,
   requireTab,
@@ -36,6 +37,16 @@ import type { X402Request } from '@dexterai/x402/server';
 // ─── Config (env is for secrets + deploy knobs; defaults run out of the box) ──
 
 const PORT = Number(process.env.PORT || 4880);
+const TAB_LEDGER_DIR = process.env.TAB_LEDGER_DIR || '.tab-ledger';
+function requireChannelIdCutover(): 'legacy-case-aliases-migrated-or-empty' {
+  if (process.env.TAB_CHANNEL_ID_CUTOVER !== 'legacy-case-aliases-migrated-or-empty') {
+    throw new Error(
+      'Set TAB_CHANNEL_ID_CUTOVER=legacy-case-aliases-migrated-or-empty only after ' +
+        'the seller ledger is empty or the documented legacy case-alias migration is complete',
+    );
+  }
+  return process.env.TAB_CHANNEL_ID_CUTOVER;
+}
 
 // Any Solana mainnet RPC. Used once per tab session (a registration read on
 // open) — never on the 402 path, never per send. Use a real provider
@@ -194,12 +205,17 @@ async function deliver(body: SendBody): Promise<DeliveryOutcome> {
 // ─── The paywall + the route ──────────────────────────────────────────────────
 
 const connection = new Connection(RPC_URL, 'confirmed');
+const ledger = new FileChannelLedger(TAB_LEDGER_DIR, {
+  channelIdCutover: requireChannelIdCutover(),
+});
 
 const paywall = tabOrExactMiddleware({
   connection,
   sellerPubkey: SELLER_PAYTO,
   network: 'solana:mainnet',
   perUnit: STICKER_HUMAN,
+  ledger,
+  ledgerSafetyMode: 'production-single-instance',
   description:
     'Page a human over Telegram or email. $0.01 per send. Tab-metered: open a ' +
     'non-custodial, hard-capped spend tab and page as you go, or pay one-shot.',

--- a/scripts/proof-of-dual.mjs
+++ b/scripts/proof-of-dual.mjs
@@ -4,7 +4,10 @@
  *   resolve  -> resolveTabTerms(url): terms with zero payment
  *   exact    -> payAndFetch + keypair wallet (the catalog verifier's path)
  *   tab      -> payUrlWithTab -> close -> mainnet settle (the agent's path)
- * Run: node scripts/proof-of-dual.mjs   (ORCHESTRATOR ONLY — mainnet)
+ * Run (ORCHESTRATOR ONLY — mainnet, after empty-store/migration proof):
+ *   TAB_LEDGER_DIR=/absolute/persistent/proof-dual-ledger \
+ *   TAB_CHANNEL_ID_CUTOVER=legacy-case-aliases-migrated-or-empty \
+ *   node scripts/proof-of-dual.mjs
  */
 import { readFileSync } from 'node:fs';
 import express from 'express';
@@ -14,13 +17,36 @@ import {
   createAssociatedTokenAccountIdempotentInstruction,
 } from '@solana/spl-token';
 
-import { tabOrExactMiddleware, requireTab, openSse } from '@dexterai/x402/tab/seller';
+import {
+  FileChannelLedger,
+  tabOrExactMiddleware,
+  requireTab,
+  openSse,
+} from '@dexterai/x402/tab/seller';
 import { payUrlWithTab, resolveTabTerms } from '@dexterai/x402/tab';
 import { payAndFetch, createKeypairWallet } from '@dexterai/x402/client';
 import {
   createSolanaVaultAdapter,
   passkeySignerFromP256Keypair,
 } from '@dexterai/x402/tab/adapters/solana';
+
+function sellerLedger() {
+  const dir = process.env.TAB_LEDGER_DIR;
+  if (!dir || !dir.startsWith('/')) {
+    throw new Error('TAB_LEDGER_DIR must be an absolute persistent directory');
+  }
+  if (process.env.TAB_CHANNEL_ID_CUTOVER !== 'legacy-case-aliases-migrated-or-empty') {
+    throw new Error(
+      'set TAB_CHANNEL_ID_CUTOVER only after the ledger is empty or the legacy case-alias migration is complete',
+    );
+  }
+  return new FileChannelLedger(dir, {
+    channelIdCutover: process.env.TAB_CHANNEL_ID_CUTOVER,
+  });
+}
+// Module-level, side-effect-free fail-fast gate: no credential read, RPC call,
+// signature, or transaction can happen before seller durability is valid.
+const SELLER_LEDGER = sellerLedger();
 
 // ── Config (identical to proof-of-loop.mjs except seller seed + port) ──
 // Write-capable Solana RPC (the proofs SEND transactions; the public
@@ -98,6 +124,8 @@ async function main() {
     network: 'solana:mainnet',
     perUnit: PER_TICK,
     facilitatorUrl: FACILITATOR,
+    ledger: SELLER_LEDGER,
+    ledgerSafetyMode: 'production-single-instance',
   });
   app.get('/paid/tick', dual, async (req, res) => {
     if (req.x402) {
@@ -108,7 +136,7 @@ async function main() {
     const meter = openSse(res, { tab, perUnit: PER_TICK });
     await meter.charge(1);
     meter.send(JSON.stringify({ message: 'hello, paid world', paidVia: 'tab' }));
-    meter.end();
+    await meter.end();
   });
   const server = app.listen(PORT);
   const url = `http://127.0.0.1:${PORT}/paid/tick`;

--- a/scripts/proof-of-loop.mjs
+++ b/scripts/proof-of-loop.mjs
@@ -14,7 +14,10 @@
  *   buyer pays w/ voucher  -> seller verifies (V6 session PDA), charges, serves
  *   buyer close()          -> POST /tab/settle -> on-chain USDC swig->seller + fee split
  *
- * Run: node scripts/proof-of-loop.mjs
+ * Run (after proving the ledger path empty or migrating legacy case aliases):
+ *   TAB_LEDGER_DIR=/absolute/persistent/proof-loop-ledger \
+ *   TAB_CHANNEL_ID_CUTOVER=legacy-case-aliases-migrated-or-empty \
+ *   node scripts/proof-of-loop.mjs
  */
 import { readFileSync } from 'node:fs';
 import express from 'express';
@@ -26,12 +29,36 @@ import {
   createAssociatedTokenAccountIdempotentInstruction,
 } from '@solana/spl-token';
 
-import { tabMiddleware, tabChallengeMiddleware, requireTab, openSse } from '@dexterai/x402/tab/seller';
+import {
+  FileChannelLedger,
+  tabMiddleware,
+  tabChallengeMiddleware,
+  requireTab,
+  openSse,
+} from '@dexterai/x402/tab/seller';
 import { payUrlWithTab } from '@dexterai/x402/tab';
 import {
   createSolanaVaultAdapter,
   passkeySignerFromP256Keypair,
 } from '@dexterai/x402/tab/adapters/solana';
+
+function sellerLedger() {
+  const dir = process.env.TAB_LEDGER_DIR;
+  if (!dir || !dir.startsWith('/')) {
+    throw new Error('TAB_LEDGER_DIR must be an absolute persistent directory');
+  }
+  if (process.env.TAB_CHANNEL_ID_CUTOVER !== 'legacy-case-aliases-migrated-or-empty') {
+    throw new Error(
+      'set TAB_CHANNEL_ID_CUTOVER only after the ledger is empty or the legacy case-alias migration is complete',
+    );
+  }
+  return new FileChannelLedger(dir, {
+    channelIdCutover: process.env.TAB_CHANNEL_ID_CUTOVER,
+  });
+}
+// Module-level, side-effect-free fail-fast gate: no credential read, RPC call,
+// signature, or transaction can happen before seller durability is valid.
+const SELLER_LEDGER = sellerLedger();
 
 // ── Config ──────────────────────────────────────────────────────────────
 // Write-capable Solana RPC (the proofs SEND transactions; the public
@@ -118,6 +145,8 @@ async function main() {
     perUnit: PER_TICK,
     settle: 'on-close',
     facilitatorUrl: FACILITATOR,
+    ledger: SELLER_LEDGER,
+    ledgerSafetyMode: 'production-single-instance',
   });
   app.get('/paid/tick', challenge, mw, async (req, res) => {
     const tab = requireTab(req);
@@ -126,7 +155,7 @@ async function main() {
     await meter.charge(1);
     meter.send(JSON.stringify({ message: 'hello, paid world', servedBy: seller.publicKey.toBase58() }));
     log('seller: charged 1 tick, sent payload, closing');
-    meter.end();
+    await meter.end();
   });
   const server = app.listen(PORT);
   log('seller listening on', PORT);

--- a/src/tab/seller/__tests__/channel-ledger.test.ts
+++ b/src/tab/seller/__tests__/channel-ledger.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { InMemoryChannelLedger, withChannelLock, type ChannelLedgerEntry } from '../channel-ledger';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ChannelLeaseLostError,
+  FileChannelLedger,
+  InMemoryChannelLedger,
+  type ChannelLedger,
+  type ChannelLedgerEntry,
+  type ChannelLease,
+} from '../channel-ledger';
 import type { SignedVoucher } from '../../types';
 
 function fakeVoucher(channelId: string, cumulativeAmount: string): SignedVoucher {
@@ -11,12 +18,56 @@ function fakeVoucher(channelId: string, cumulativeAmount: string): SignedVoucher
   };
 }
 
+async function acquire(
+  ledger: ChannelLedger,
+  channelId: string,
+  ttlMs = 60_000,
+): Promise<ChannelLease> {
+  const lease = await ledger.tryAcquireLease(channelId, ttlMs);
+  if (!lease) throw new Error('expected channel lease');
+  return lease;
+}
+
+async function seed(
+  ledger: ChannelLedger,
+  channelId: string,
+  entry: ChannelLedgerEntry,
+): Promise<void> {
+  const lease = await acquire(ledger, channelId);
+  await ledger.set(channelId, entry, lease);
+  expect(await ledger.releaseLease(channelId, lease)).toBe(true);
+}
+
 describe('InMemoryChannelLedger', () => {
   const channelId = 'a'.repeat(64);
 
   it('returns null for an unknown channel', async () => {
     const ledger = new InMemoryChannelLedger();
     expect(await ledger.get(channelId)).toBeNull();
+    expect(ledger.capabilities).toEqual({
+      adapter: 'memory',
+      restartSafe: false,
+      multiInstanceSafe: false,
+      conditionalWrites: true,
+      canonicalChannelIds: true,
+    });
+  });
+
+  it('rejects noncanonical case before creating an alias key', async () => {
+    const ledger = new InMemoryChannelLedger();
+    await expect(ledger.get('A'.repeat(64))).rejects.toThrow(/canonical lowercase/);
+    expect(await ledger.get('a'.repeat(64))).toBeNull();
+  });
+
+  it('does not expose an unfenced mutable reference from get()', async () => {
+    const ledger = new InMemoryChannelLedger();
+    await seed(ledger, channelId, {
+      lastVoucher: fakeVoucher(channelId, '10'),
+      deliveredCumulativeAtomic: '1',
+    });
+    const detached = await ledger.get(channelId);
+    detached!.deliveredCumulativeAtomic = '999';
+    expect((await ledger.get(channelId))?.deliveredCumulativeAtomic).toBe('1');
   });
 
   it('roundtrips lastVoucher + deliveredCumulativeAtomic', async () => {
@@ -25,7 +76,7 @@ describe('InMemoryChannelLedger', () => {
       lastVoucher: fakeVoucher(channelId, '100000'),
       deliveredCumulativeAtomic: '50000',
     };
-    await ledger.set(channelId, entry);
+    await seed(ledger, channelId, entry);
     const got = await ledger.get(channelId);
     expect(got?.deliveredCumulativeAtomic).toBe('50000');
     expect(got?.lastVoucher?.payload.cumulativeAmount).toBe('100000');
@@ -33,7 +84,7 @@ describe('InMemoryChannelLedger', () => {
 
   it('preserves the optional onChain snapshot when present', async () => {
     const ledger = new InMemoryChannelLedger();
-    await ledger.set(channelId, {
+    await seed(ledger, channelId, {
       lastVoucher: fakeVoucher(channelId, '100000'),
       deliveredCumulativeAtomic: '0',
       onChain: {
@@ -50,31 +101,32 @@ describe('InMemoryChannelLedger', () => {
 
   it('deletes a channel', async () => {
     const ledger = new InMemoryChannelLedger();
-    await ledger.set(channelId, { lastVoucher: fakeVoucher(channelId, '1'), deliveredCumulativeAtomic: '0' });
-    await ledger.delete(channelId);
+    const lease = await acquire(ledger, channelId);
+    await ledger.set(channelId, { lastVoucher: fakeVoucher(channelId, '1'), deliveredCumulativeAtomic: '0' }, lease);
+    await ledger.delete(channelId, lease);
+    expect(await ledger.releaseLease(channelId, lease)).toBe(true);
     expect(await ledger.get(channelId)).toBeNull();
   });
 });
 
-import { FileChannelLedger } from '../channel-ledger';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join as pathJoin } from 'node:path';
 
-describe('withChannelLock — serializes concurrent read-modify-write', () => {
+describe('ChannelLedger.update — serializes concurrent read-modify-write', () => {
   it('10 concurrent +1 increments on one channel do not lose updates', async () => {
     const ledger = new InMemoryChannelLedger();
     const channelId = 'e'.repeat(64);
-    await ledger.set(channelId, { lastVoucher: fakeVoucher(channelId, '0'), deliveredCumulativeAtomic: '0' });
+    const lease = await acquire(ledger, channelId);
+    await ledger.set(channelId, { lastVoucher: fakeVoucher(channelId, '0'), deliveredCumulativeAtomic: '0' }, lease);
     await Promise.all(Array.from({ length: 10 }, () =>
-      withChannelLock(channelId, async () => {
-        const cur = await ledger.get(channelId);
+      ledger.update(channelId, lease, (cur) => {
         const base = BigInt(cur!.deliveredCumulativeAtomic);
-        await new Promise((r) => setTimeout(r, 1)); // async gap to expose races
-        await ledger.set(channelId, { ...cur!, deliveredCumulativeAtomic: (base + 1n).toString() });
+        return { ...cur!, deliveredCumulativeAtomic: (base + 1n).toString() };
       }),
     ));
     expect((await ledger.get(channelId))?.deliveredCumulativeAtomic).toBe('10');
+    await ledger.releaseLease(channelId, lease);
   });
 });
 
@@ -85,7 +137,7 @@ describe('FileChannelLedger', () => {
     const dir = await mkdtemp(pathJoin(tmpdir(), 'chanledger-'));
     try {
       const writer = new FileChannelLedger(dir);
-      await writer.set(channelId, {
+      await seed(writer, channelId, {
         lastVoucher: fakeVoucher(channelId, '200000'),
         deliveredCumulativeAtomic: '150000',
       });
@@ -100,17 +152,31 @@ describe('FileChannelLedger', () => {
     }
   });
 
-  it('returns null for a missing file and rejects unsafe channel ids', async () => {
+  it('returns null for a missing file and rejects noncanonical channel ids', async () => {
     const dir = await mkdtemp(pathJoin(tmpdir(), 'chanledger-'));
     try {
       const ledger = new FileChannelLedger(dir);
       expect(await ledger.get('c'.repeat(64))).toBeNull();
       await expect(
-        ledger.set('../escape', { lastVoucher: fakeVoucher('x', '1'), deliveredCumulativeAtomic: '0' }),
-      ).rejects.toThrow(/unsafe channelId/);
+        ledger.tryAcquireLease('../escape', 60_000),
+      ).rejects.toThrow(/canonical lowercase/);
+      await expect(ledger.get('B'.repeat(64))).rejects.toThrow(/canonical lowercase/);
+      expect(await ledger.get('b'.repeat(64))).toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it('advertises canonical safety only after the explicit alias cutover acknowledgement', () => {
+    const unacknowledged = new FileChannelLedger('/tmp/channel-ledger-capability');
+    const acknowledged = new FileChannelLedger('/tmp/channel-ledger-capability', {
+      channelIdCutover: 'legacy-case-aliases-migrated-or-empty',
+    });
+    expect(unacknowledged.capabilities.canonicalChannelIds).toBe(false);
+    expect(acknowledged.capabilities.canonicalChannelIds).toBe(true);
+    expect(() => new FileChannelLedger('/tmp/channel-ledger-capability', {
+      channelIdCutover: 'wrong' as any,
+    })).toThrow(/channelIdCutover/);
   });
 
   // K-T3 (cadence §5 A12): the gate-refused watermark must survive a restart,
@@ -119,11 +185,12 @@ describe('FileChannelLedger', () => {
     const dir = await mkdtemp(pathJoin(tmpdir(), 'chanledger-'));
     try {
       const writer = new FileChannelLedger(dir);
+      const lease = await acquire(writer, channelId);
       await writer.set(channelId, {
         lastVoucher: fakeVoucher(channelId, '200000'),
         deliveredCumulativeAtomic: '150000',
         gateRefusedCumulativeAtomic: '200000',
-      });
+      }, lease);
       const reader = new FileChannelLedger(dir);
       const got = await reader.get(channelId);
       expect(got?.gateRefusedCumulativeAtomic).toBe('200000');
@@ -131,9 +198,10 @@ describe('FileChannelLedger', () => {
       await writer.set(channelId, {
         lastVoucher: fakeVoucher(channelId, '200000'),
         deliveredCumulativeAtomic: '150000',
-      });
+      }, lease);
       const got2 = await reader.get(channelId);
       expect(got2?.gateRefusedCumulativeAtomic).toBeUndefined();
+      await writer.releaseLease(channelId, lease);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -143,61 +211,98 @@ describe('FileChannelLedger', () => {
 describe('channel lease — reject concurrent same-channel metering', () => {
   const channelId = 'f'.repeat(64);
 
+  it('rejects non-finite, fractional, tiny, and timer-overflow TTLs', async () => {
+    const ledger = new InMemoryChannelLedger();
+    for (const invalid of [NaN, Infinity, 0, 2.5, 0x8000_0000]) {
+      await expect(ledger.tryAcquireLease(channelId, invalid)).rejects.toThrow(
+        /lease TTL must be an integer from 3 to 2147483647/,
+      );
+    }
+  });
+
   it('acquires when free, refuses while held, re-acquires after release', async () => {
     const ledger = new InMemoryChannelLedger();
-    expect(await ledger.tryAcquireLease(channelId, 60_000)).toBe(true);
-    expect(await ledger.tryAcquireLease(channelId, 60_000)).toBe(false); // held
-    await ledger.releaseLease(channelId);
-    expect(await ledger.tryAcquireLease(channelId, 60_000)).toBe(true);  // free again
+    const first = await acquire(ledger, channelId);
+    expect(await ledger.tryAcquireLease(channelId, 60_000)).toBeNull(); // held
+    expect(await ledger.releaseLease(channelId, first)).toBe(true);
+    const second = await acquire(ledger, channelId);
+    expect(BigInt(second.fence)).toBeGreaterThan(BigInt(first.fence));
   });
 
   it('re-acquires after the lease TTL expires (crashed-holder safety)', async () => {
     const ledger = new InMemoryChannelLedger();
-    expect(await ledger.tryAcquireLease(channelId, 5)).toBe(true); // 5ms TTL
+    const crashed = await acquire(ledger, channelId, 5);
     await new Promise((r) => setTimeout(r, 15));
-    expect(await ledger.tryAcquireLease(channelId, 60_000)).toBe(true); // expired → free
+    const takeover = await acquire(ledger, channelId); // expired → free
+    expect(BigInt(takeover.fence)).toBeGreaterThan(BigInt(crashed.fence));
   });
 
   it('preserves deliveredCumulative across lease acquire/release', async () => {
     const ledger = new InMemoryChannelLedger();
-    await ledger.set(channelId, { lastVoucher: fakeVoucher(channelId, '100000'), deliveredCumulativeAtomic: '70000' });
-    await ledger.tryAcquireLease(channelId, 60_000);
-    await ledger.releaseLease(channelId);
+    await seed(ledger, channelId, { lastVoucher: fakeVoucher(channelId, '100000'), deliveredCumulativeAtomic: '70000' });
     expect((await ledger.get(channelId))?.deliveredCumulativeAtomic).toBe('70000');
   });
 
-  it('a voucher-persist-style set that spreads ...cur PRESERVES the lease (BUG 1 guard)', async () => {
+  it('rejects stale writes and stale release after crash takeover', async () => {
     const ledger = new InMemoryChannelLedger();
     const ch = 'b'.repeat(64);
-    expect(await ledger.tryAcquireLease(ch, 60_000)).toBe(true);
-    // Mirror the middleware step-6 voucher persist: spread cur, then overwrite
-    // lastVoucher + delivered. Omitting ...cur would erase the lease.
-    const cur = await ledger.get(ch);
-    await ledger.set(ch, { ...cur!, lastVoucher: fakeVoucher(ch, '1000'), deliveredCumulativeAtomic: '0' });
-    // Lease must still be held — a concurrent acquire fails.
-    expect(await ledger.tryAcquireLease(ch, 60_000)).toBe(false);
-
-    // Mirror the recordDelivered persist: another ...cur set advancing delivered.
-    const cur2 = await ledger.get(ch);
-    await ledger.set(ch, { ...cur2!, deliveredCumulativeAtomic: '5' });
-    // Lease STILL held after the second write.
-    expect(await ledger.tryAcquireLease(ch, 60_000)).toBe(false);
-    expect((await ledger.get(ch))?.deliveredCumulativeAtomic).toBe('5');
+    const crashed = await acquire(ledger, ch, 5);
+    await ledger.set(ch, { lastVoucher: fakeVoucher(ch, '1000'), deliveredCumulativeAtomic: '1' }, crashed);
+    await new Promise((r) => setTimeout(r, 15));
+    const takeover = await acquire(ledger, ch);
+    await ledger.update(ch, takeover, (cur) => ({ ...cur!, deliveredCumulativeAtomic: '2' }));
+    await expect(
+      ledger.update(ch, crashed, (cur) => ({ ...cur!, deliveredCumulativeAtomic: '999' })),
+    ).rejects.toBeInstanceOf(ChannelLeaseLostError);
+    expect(await ledger.releaseLease(ch, crashed)).toBe(false);
+    expect((await ledger.get(ch))?.deliveredCumulativeAtomic).toBe('2');
   });
 
   it('FileChannelLedger acquires a lease on a FRESH channel without throwing (durable-path regression)', async () => {
-    // The first request on any channel acquires the lease BEFORE any voucher is
-    // persisted (middleware step 5b precedes step 6). On a durable/file ledger
-    // that means serializing a lease-only entry with no voucher — must not throw.
+    // The first request acquires before a voucher is persisted. Lease metadata
+    // is separate, so acquisition must not fabricate revenue history.
     const dir = await mkdtemp(pathJoin(tmpdir(), 'chanledger-'));
     try {
       const fresh = 'a'.repeat(64);
       const ledger = new FileChannelLedger(dir);
-      expect(await ledger.tryAcquireLease(fresh, 60_000)).toBe(true);
+      const lease = await acquire(ledger, fresh);
       const got = await ledger.get(fresh);
-      expect(got?.lease?.heldUntilUnixMs).toBeGreaterThan(0);
-      expect(got?.lastVoucher).toBeNull();
+      expect(got).toBeNull(); // lease metadata is separate from revenue state
+      expect(lease.fence).toBe('1');
+      await ledger.releaseLease(fresh, lease);
     } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('FileChannelLedger persists its fence and rejects a pre-crash writer after takeover', async () => {
+    const dir = await mkdtemp(pathJoin(tmpdir(), 'chanledger-'));
+    vi.useFakeTimers();
+    try {
+      const beforeCrash = new FileChannelLedger(dir);
+      const stale = await acquire(beforeCrash, channelId, 5);
+      await beforeCrash.set(channelId, {
+        lastVoucher: fakeVoucher(channelId, '10'),
+        deliveredCumulativeAtomic: '1',
+      }, stale);
+      vi.advanceTimersByTime(6);
+
+      const afterRestart = new FileChannelLedger(dir);
+      const takeover = await acquire(afterRestart, channelId);
+      expect(BigInt(takeover.fence)).toBeGreaterThan(BigInt(stale.fence));
+      await afterRestart.update(channelId, takeover, (cur) => ({
+        ...cur!,
+        deliveredCumulativeAtomic: '2',
+      }));
+      await expect(
+        beforeCrash.set(channelId, {
+          lastVoucher: fakeVoucher(channelId, '10'),
+          deliveredCumulativeAtomic: '999',
+        }, stale),
+      ).rejects.toBeInstanceOf(ChannelLeaseLostError);
+      expect((await afterRestart.get(channelId))?.deliveredCumulativeAtomic).toBe('2');
+    } finally {
+      vi.useRealTimers();
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/src/tab/seller/__tests__/dual.test.ts
+++ b/src/tab/seller/__tests__/dual.test.ts
@@ -72,7 +72,7 @@ function fakeReqRes(headers: Record<string, string> = {}) {
     originalUrl: '/paid/tick',
     get: (h: string) => (h.toLowerCase() === 'host' ? '127.0.0.1:4455' : undefined),
   };
-  const res: any = {
+  const res: any = Object.assign(new EventEmitter(), {
     statusCode: 0,
     headers: {} as Record<string, string>,
     body: undefined as unknown,
@@ -80,7 +80,7 @@ function fakeReqRes(headers: Record<string, string> = {}) {
     setHeader(name: string, value: string) { this.headers[name] = value; return this; },
     status(c: number) { this.statusCode = c; return this; },
     json(b: unknown) { this.body = b; return this; },
-  };
+  });
   return { req, res };
 }
 

--- a/src/tab/seller/__tests__/lease.test.ts
+++ b/src/tab/seller/__tests__/lease.test.ts
@@ -77,7 +77,7 @@ function fakeReqRes(header: string) {
 
 const flushMicrotasks = () => new Promise((r) => setTimeout(r, 0));
 
-function mw(ledger: InMemoryChannelLedger) {
+function mw(ledger: InMemoryChannelLedger, leaseTtlMs?: number) {
   return tabMiddleware({
     connection: fakeConnection,
     sellerPubkey: SELLER,
@@ -85,6 +85,9 @@ function mw(ledger: InMemoryChannelLedger) {
     network: 'solana:mainnet',
     settle: 'on-close',
     ledger,
+    leaseTtlMs,
+    // Lease tests do not exercise facilitator crystallization.
+    lockCadence: { thresholdAtomic: '999999999999', onClose: false },
   });
 }
 
@@ -154,5 +157,35 @@ describe('channel lease — end-to-end through tabMiddleware', () => {
     await middleware(req2, res2, next2);
     expect(next2).toHaveBeenCalledTimes(1);
     expect(res2.statusCode).toBe(0);
+  });
+
+  it('renews a healthy stream beyond its original TTL so takeover stays closed', async () => {
+    const ledger = new InMemoryChannelLedger();
+    const middleware = mw(ledger, 30);
+    const { req: req1, res: res1 } = fakeReqRes(voucherHeader(CHANNEL, '1000'));
+    await middleware(req1, res1, vi.fn());
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    const { req: req2, res: res2 } = fakeReqRes(voucherHeader(CHANNEL, '2000', 2));
+    const next2 = vi.fn();
+    await middleware(req2, res2, next2);
+    expect(next2).not.toHaveBeenCalled();
+    expect(res2.body).toMatchObject({ reason: 'channel_busy' });
+    res1.emit('close');
+    await flushMicrotasks();
+  });
+
+  it('destroys the response and stops renewing when the durable store heartbeat fails', async () => {
+    const ledger = new InMemoryChannelLedger();
+    vi.spyOn(ledger, 'renewLease').mockRejectedValue(new Error('store unavailable'));
+    const middleware = mw(ledger, 15);
+    const { req, res } = fakeReqRes(voucherHeader(CHANNEL, '1000'));
+    res.destroy = vi.fn();
+    await middleware(req, res, vi.fn());
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(res.destroy).toHaveBeenCalledWith(expect.objectContaining({ message: 'store unavailable' }));
+    res.emit('close');
+    await flushMicrotasks();
   });
 });

--- a/src/tab/seller/__tests__/meter.test.ts
+++ b/src/tab/seller/__tests__/meter.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { openSse } from '../meter';
-import { InMemoryChannelLedger } from '../channel-ledger';
+import { FileChannelLedger, InMemoryChannelLedger } from '../channel-ledger';
 import type { SellerTab } from '../types';
 import { atomicToHuman, humanToAtomic } from '../../tab';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // Minimal SSE-capable fake Express Response that records writes and supports
 // the 'close' event (for the buyer-disconnect anti-grief test).
@@ -16,6 +19,7 @@ function fakeSseRes() {
     write(s: string) { writes.push(s); return true; },
     end() {},
     on(event: string, cb: () => void) { (listeners[event] ??= []).push(cb); return this; },
+    prependListener(event: string, cb: () => void) { (listeners[event] ??= []).unshift(cb); return this; },
     _emit(event: string) { (listeners[event] ?? []).forEach((cb) => cb()); },
     _writes: writes,
   } as any;
@@ -31,7 +35,9 @@ async function makeStubTab(
   channelId: string,
   signedCumulativeHuman: string,
   ledger: InMemoryChannelLedger,
-): Promise<SellerTab> {
+): Promise<SellerTab & { releaseLease(): Promise<void> }> {
+  const lease = await ledger.tryAcquireLease(channelId, 60_000);
+  if (!lease) throw new Error('expected test channel lease');
   const prior = await ledger.get(channelId);
   const deliveredBaselineAtomic = prior ? prior.deliveredCumulativeAtomic : '0';
   return {
@@ -41,17 +47,19 @@ async function makeStubTab(
     cumulative: () => signedCumulativeHuman,
     deliveredCumulative: () => atomicToHuman(deliveredBaselineAtomic),
     charge: async () => { throw new Error('tab.charge stub'); },
+    releaseLease: async () => { await ledger.releaseLease(channelId, lease); },
     recordDelivered: async (incrementAtomic: string) => {
-      const cur = await ledger.get(channelId);
-      const base = cur ? BigInt(cur.deliveredCumulativeAtomic) : 0n;
-      await ledger.set(channelId, {
-        lastVoucher: cur?.lastVoucher ?? ({
-          payload: { channelId, cumulativeAmount: humanToAtomic(signedCumulativeHuman), sequenceNumber: 1 },
-          sessionPublicKey: new Uint8Array(32),
-          sessionRegistration: new Uint8Array(188),
-          sessionSignature: new Uint8Array(64),
-        } as any),
-        deliveredCumulativeAtomic: (base + (BigInt(incrementAtomic) > 0n ? BigInt(incrementAtomic) : 0n)).toString(),
+      await ledger.update(channelId, lease, (cur) => {
+        const base = cur ? BigInt(cur.deliveredCumulativeAtomic) : 0n;
+        return {
+          lastVoucher: cur?.lastVoucher ?? ({
+            payload: { channelId, cumulativeAmount: humanToAtomic(signedCumulativeHuman), sequenceNumber: 1 },
+            sessionPublicKey: new Uint8Array(32),
+            sessionRegistration: new Uint8Array(188),
+            sessionSignature: new Uint8Array(64),
+          } as any),
+          deliveredCumulativeAtomic: (base + (BigInt(incrementAtomic) > 0n ? BigInt(incrementAtomic) : 0n)).toString(),
+        };
       });
     },
   };
@@ -78,6 +86,7 @@ describe('openSse delivered-ledger budget — no channel-reuse leak', () => {
     const m1 = openSse(fakeSseRes(), { tab: tab1, perUnit: '0.01' });
     for (let i = 0; i < 5; i++) await m1.charge(1); // 0.05 delivered
     await m1.end();
+    await tab1.releaseLease();
     expect((await ledger.get(channelId))?.deliveredCumulativeAtomic).toBe(humanToAtomic('0.05'));
 
     // Request 2: buyer bumps signed to 0.20. Correct budget = 0.20 − 0.05 = 0.15
@@ -128,6 +137,101 @@ describe('openSse delivered-ledger budget — no channel-reuse leak', () => {
     res._emit('close');    // would fire after res.end(); must be a no-op
     await flushMicrotasks();
     expect((await ledger.get(channelId))?.deliveredCumulativeAtomic).toBe(humanToAtomic('0.01'));
+  });
+
+  it('write-ahead persists a charged chunk across hard crash before send', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'meter-crash-ledger-'));
+    let nowSpy: ReturnType<typeof vi.spyOn> | undefined;
+    try {
+      const beforeCrash = new FileChannelLedger(dir);
+      const lease = await beforeCrash.tryAcquireLease(channelId, 60_000);
+      if (!lease) throw new Error('expected crash-test lease');
+      const tab: SellerTab = {
+        channelId,
+        network: 'solana:mainnet',
+        sessionPublicKey: new Uint8Array(32),
+        cumulative: () => '0.10',
+        deliveredCumulative: () => '0',
+        charge: async () => { throw new Error('unused'); },
+        recordDelivered: async (incrementAtomic) => {
+          await beforeCrash.update(channelId, lease, (cur) => ({
+            lastVoucher: cur?.lastVoucher ?? null,
+            deliveredCumulativeAtomic: (
+              BigInt(cur?.deliveredCumulativeAtomic ?? '0') + BigInt(incrementAtomic)
+            ).toString(),
+          }));
+        },
+      };
+      const meter = openSse(fakeSseRes(), { tab, perUnit: '0.01' });
+      await meter.charge(1);
+      // Process dies here: no send(), end(), close handler, or release.
+      // Advance beyond the abandoned lease deterministically; a wall-clock
+      // sleep made this regression flaky under the full parallel suite.
+      nowSpy = vi.spyOn(Date, 'now').mockReturnValue(lease.heldUntilUnixMs + 1);
+      const afterRestart = new FileChannelLedger(dir);
+      expect((await afterRestart.get(channelId))?.deliveredCumulativeAtomic)
+        .toBe(humanToAtomic('0.01'));
+      const takeover = await afterRestart.tryAcquireLease(channelId, 60_000);
+      expect(takeover).not.toBeNull();
+    } finally {
+      nowSpy?.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails before send when the write-ahead store mutation fails', async () => {
+    const res = fakeSseRes();
+    const tab: SellerTab = {
+      channelId,
+      network: 'solana:mainnet',
+      sessionPublicKey: new Uint8Array(32),
+      cumulative: () => '0.10',
+      deliveredCumulative: () => '0',
+      charge: async () => { throw new Error('unused'); },
+      recordDelivered: async () => { throw new Error('store unavailable'); },
+    };
+    const meter = openSse(res, { tab, perUnit: '0.01' });
+    await expect(meter.charge()).rejects.toThrow('store unavailable');
+    expect(() => meter.send('must-not-send')).toThrow('meter ended');
+    expect(res._writes).toEqual([]);
+  });
+
+  it('serializes concurrent charges so only signed budget reaches durable state', async () => {
+    const ledger = new InMemoryChannelLedger();
+    const tab = await makeStubTab(channelId, '0.01', ledger);
+    const meter = openSse(fakeSseRes(), { tab, perUnit: '0.01' });
+
+    const results = await Promise.allSettled([meter.charge(1), meter.charge(1)]);
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect((await ledger.get(channelId))?.deliveredCumulativeAtomic)
+      .toBe(humanToAtomic('0.01'));
+  });
+
+  it('send fails synchronously while an un-awaited write-ahead charge is pending', async () => {
+    let finishWrite!: () => void;
+    const writePending = new Promise<void>((resolve) => {
+      finishWrite = resolve;
+    });
+    const res = fakeSseRes();
+    const tab: SellerTab = {
+      channelId,
+      network: 'solana:mainnet',
+      sessionPublicKey: new Uint8Array(32),
+      cumulative: () => '0.01',
+      deliveredCumulative: () => '0',
+      charge: async () => { throw new Error('unused'); },
+      recordDelivered: async () => writePending,
+    };
+    const meter = openSse(res, { tab, perUnit: '0.01' });
+
+    const chargePending = meter.charge();
+    expect(() => meter.send('too-early')).toThrow(/charge still pending/);
+    expect(res._writes).toEqual([]);
+    finishWrite();
+    await chargePending;
+    meter.send('after-commit');
+    expect(res._writes).toHaveLength(1);
   });
 });
 

--- a/src/tab/seller/__tests__/middleware-crystallize.test.ts
+++ b/src/tab/seller/__tests__/middleware-crystallize.test.ts
@@ -40,11 +40,16 @@ const fakeConnection = {} as any;
 
 /** Base64-JSON voucher header the middleware can decode. cumulativeAmount is the
  *  signed cumulative for THIS channel — the value that must get crystallized. */
-function voucherHeader(channelId: string, cumulativeAmount: string, sequenceNumber = 1): string {
+function voucherHeader(
+  channelId: string,
+  cumulativeAmount: string,
+  sequenceNumber = 1,
+  registrationHex = '00'.repeat(188),
+): string {
   const voucher = {
     payload: { channelId, cumulativeAmount, sequenceNumber },
     sessionPublicKey: '00'.repeat(32),
-    sessionRegistration: '00'.repeat(188),
+    sessionRegistration: registrationHex,
     sessionSignature: '00'.repeat(64),
   };
   return Buffer.from(JSON.stringify(voucher), 'utf8').toString('base64');
@@ -276,5 +281,122 @@ describe('tabMiddleware close-path crystallize (FIX C2)', () => {
     await middleware(req2, res2, next2);
     expect(next2).toHaveBeenCalledTimes(1);
     expect(res2.statusCode).toBe(0);
+  });
+
+  it('allows V1 reconnect headroom only with a strictly newer durable sequence', async () => {
+    const ledger = new InMemoryChannelLedger();
+    const middleware = mw(ledger, {
+      thresholdAtomic: humanToAtomic('1000000'),
+      onClose: false,
+    });
+    const cumulative = humanToAtomic('0.05');
+
+    const first = fakeReqRes(voucherHeader(CHANNEL, cumulative, 1));
+    const firstNext = vi.fn();
+    await middleware(first.req, first.res, firstNext);
+    expect(firstNext).toHaveBeenCalledOnce();
+    first.res.emit('close');
+    await flushMicrotasks();
+
+    const replay = fakeReqRes(voucherHeader(CHANNEL, cumulative, 1));
+    const replayNext = vi.fn();
+    await middleware(replay.req, replay.res, replayNext);
+    expect(replayNext).not.toHaveBeenCalled();
+    expect(replay.res.body).toMatchObject({ reason: 'non_monotonic' });
+
+    const reconnect = fakeReqRes(voucherHeader(CHANNEL, cumulative, 2));
+    const reconnectNext = vi.fn();
+    await middleware(reconnect.req, reconnect.res, reconnectNext);
+    expect(reconnectNext).toHaveBeenCalledOnce();
+    reconnect.res.emit('close');
+    await flushMicrotasks();
+  });
+
+  it('rejects a case-flipped spelling of the same signed channel bytes', async () => {
+    const ledger = new InMemoryChannelLedger();
+    const middleware = mw(ledger, {
+      thresholdAtomic: humanToAtomic('1000000'),
+      onClose: false,
+    });
+    const cumulative = humanToAtomic('0.05');
+
+    const canonical = fakeReqRes(voucherHeader(CHANNEL, cumulative, 1));
+    await middleware(canonical.req, canonical.res, vi.fn());
+    canonical.res.emit('close');
+    await flushMicrotasks();
+
+    // Hex decoding would produce the same 32 signed bytes, but raw-case keys
+    // would create a second cache/lease/ledger identity without this guard.
+    const flippedChannel = CHANNEL.toUpperCase();
+    const replay = fakeReqRes(voucherHeader(flippedChannel, cumulative, 2));
+    const replayNext = vi.fn();
+    await middleware(replay.req, replay.res, replayNext);
+    expect(replayNext).not.toHaveBeenCalled();
+    expect(replay.res.body).toMatchObject({ reason: 'signature_invalid' });
+    await expect(ledger.get(flippedChannel)).rejects.toThrow(/canonical lowercase/);
+    expect((await ledger.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('0');
+  });
+
+  it('does not cache a first-seen V1 registration that loses the durable lease', async () => {
+    const ledger = new InMemoryChannelLedger();
+    const acquire = ledger.tryAcquireLease.bind(ledger);
+    vi.spyOn(ledger, 'tryAcquireLease')
+      .mockResolvedValueOnce(null)
+      .mockImplementation(acquire);
+    const middleware = mw(ledger, {
+      thresholdAtomic: humanToAtomic('1000000'),
+      onClose: false,
+    });
+    const cumulative = humanToAtomic('0.01');
+
+    const loser = fakeReqRes(voucherHeader(
+      CHANNEL,
+      cumulative,
+      1,
+      '11'.repeat(188),
+    ));
+    await middleware(loser.req, loser.res, vi.fn());
+    expect(loser.res.body).toMatchObject({ reason: 'channel_busy' });
+
+    const legitimate = fakeReqRes(voucherHeader(
+      CHANNEL,
+      cumulative,
+      1,
+      '22'.repeat(188),
+    ));
+    const next = vi.fn();
+    await middleware(legitimate.req, legitimate.res, next);
+    expect(next).toHaveBeenCalledOnce();
+
+    legitimate.res.emit('close');
+    await flushMicrotasks();
+  });
+
+  it('caps two meters sharing one admitted SellerTab at the durable signed cumulative', async () => {
+    const ledger = new InMemoryChannelLedger();
+    const middleware = mw(ledger, {
+      thresholdAtomic: humanToAtomic('1000000'),
+      onClose: false,
+    });
+    const signedAtomic = humanToAtomic('0.01');
+    const admitted = fakeReqRes(voucherHeader(CHANNEL, signedAtomic, 1));
+    const next = vi.fn();
+    await middleware(admitted.req, admitted.res, next);
+    expect(next).toHaveBeenCalledOnce();
+
+    const tab = requireTab(admitted.req);
+    // Both meters snapshot the same zero delivered baseline and each locally
+    // sees the full signed remainder. The fenced ledger mutation is therefore
+    // the authoritative shared cap boundary, not either meter's local counter.
+    const first = openSse(fakeReqRes('').res, { tab, perUnit: '0.01' });
+    const second = openSse(fakeReqRes('').res, { tab, perUnit: '0.01' });
+    const results = await Promise.allSettled([first.charge(1), second.charge(1)]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect((await ledger.get(CHANNEL))?.deliveredCumulativeAtomic).toBe(signedAtomic);
+
+    admitted.res.emit('close');
+    await flushMicrotasks();
   });
 });

--- a/src/tab/seller/__tests__/middleware-frontier.test.ts
+++ b/src/tab/seller/__tests__/middleware-frontier.test.ts
@@ -166,6 +166,8 @@ describe('chain-frontier baseline seeding', () => {
 
     const ledger = new InMemoryChannelLedger();
     // Pre-existing history: seller already delivered 0.02 on this channel.
+    const seedLease = await ledger.tryAcquireLease(CHANNEL, 60_000);
+    if (!seedLease) throw new Error('expected seed lease');
     await ledger.set(CHANNEL, {
       lastVoucher: {
         payload: { channelId: CHANNEL, cumulativeAmount: humanToAtomic('0.02'), sequenceNumber: 1 },
@@ -175,7 +177,8 @@ describe('chain-frontier baseline seeding', () => {
       },
       deliveredCumulativeAtomic: humanToAtomic('0.02'),
       lastCrystallizedCumulativeAtomic: '0',
-    });
+    }, seedLease);
+    await ledger.releaseLease(CHANNEL, seedLease);
 
     const middleware = mw(ledger);
     const { req, res } = fakeReqRes(voucherHeader(CHANNEL, humanToAtomic('0.10'), 2));

--- a/src/tab/seller/__tests__/middleware-ledger.test.ts
+++ b/src/tab/seller/__tests__/middleware-ledger.test.ts
@@ -1,11 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { tabMiddleware } from '../middleware';
-import { InMemoryChannelLedger } from '../channel-ledger';
+import { tabOrExactMiddleware } from '../dual';
+import { FileChannelLedger, InMemoryChannelLedger } from '../channel-ledger';
+import { RedisChannelLedger, type RedisLikeClient } from '../redis-channel-ledger';
 import { Connection } from '@solana/web3.js';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const SELLER = '9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin';
 
 describe('tabMiddleware ledger config', () => {
+  const base = {
+    connection: new Connection('http://127.0.0.1:8899'),
+    sellerPubkey: SELLER,
+    perUnit: '0.01' as const,
+    network: 'solana:mainnet' as const,
+    settle: 'on-close' as const,
+  };
+
   it('accepts a ChannelLedger and rejects a request with no voucher header (402) without touching the ledger', async () => {
     const ledger = new InMemoryChannelLedger();
     const mw = tabMiddleware({
@@ -19,13 +33,131 @@ describe('tabMiddleware ledger config', () => {
     let status = 0;
     let body: any;
     const req: any = { headers: {} };
-    const res: any = {
+    const res: any = Object.assign(new EventEmitter(), {
       status(c: number) { status = c; return this; },
       json(b: unknown) { body = b; return this; },
-    };
+    });
     await mw(req, res, () => { throw new Error('next should not be called'); });
     expect(status).toBe(402);
     expect(body.error).toBe('invalid_voucher');
-    expect(await ledger.get('whatever'.padEnd(64, '0'))).toBeNull();
+    expect(await ledger.get('f'.repeat(64))).toBeNull();
+  });
+
+  it('fails closed instead of silently using memory in production', () => {
+    expect(() => tabMiddleware({
+      ...base,
+      ledgerSafetyMode: 'production-single-instance',
+    })).toThrow(/requires restart-safe durable ledger state/);
+    expect(() => tabMiddleware({
+      ...base,
+      ledger: new FileChannelLedger('/tmp/dexter-ledger-capability-only'),
+      ledgerSafetyMode: 'production-mulit-instance' as any,
+    })).toThrow(/invalid tab seller ledgerSafetyMode/);
+  });
+
+  it('rejects an invalid lease TTL at middleware construction', () => {
+    expect(() => tabMiddleware({
+      ...base,
+      leaseTtlMs: Number.NaN,
+    })).toThrow(/lease TTL must be an integer/);
+  });
+
+  it('requires an explicit deployment topology outside exact test/development NODE_ENV', () => {
+    const prior = process.env.NODE_ENV;
+    try {
+      delete process.env.NODE_ENV;
+      expect(() => tabMiddleware({
+        ...base,
+        ledger: new FileChannelLedger('/tmp/dexter-ledger-capability-only'),
+      })).toThrow(/ledgerSafetyMode must be explicit/);
+      process.env.NODE_ENV = 'production';
+      expect(() => tabMiddleware({
+        ...base,
+        ledger: new FileChannelLedger('/tmp/dexter-ledger-capability-only'),
+      })).toThrow(/ledgerSafetyMode must be explicit/);
+    } finally {
+      if (prior === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prior;
+    }
+  });
+
+  it('admits file only for single-instance production and requires Redis-class fencing for multi-instance', () => {
+    const unacknowledgedFile = new FileChannelLedger('/tmp/dexter-ledger-capability-only');
+    expect(() => tabMiddleware({
+      ...base,
+      ledger: unacknowledgedFile,
+      ledgerSafetyMode: 'production-single-instance',
+    })).toThrow(/channel-id alias migration/);
+
+    const file = new FileChannelLedger('/tmp/dexter-ledger-capability-only', {
+      channelIdCutover: 'legacy-case-aliases-migrated-or-empty',
+    });
+    expect(() => tabMiddleware({
+      ...base,
+      ledger: file,
+      ledgerSafetyMode: 'production-single-instance',
+    })).not.toThrow();
+    expect(() => tabMiddleware({
+      ...base,
+      ledger: file,
+      ledgerSafetyMode: 'production-multi-instance',
+    })).toThrow(/cross-process atomic fencing/);
+    // Bounded construction smoke for the exact configuration now used by the
+    // mainnet proof scripts: durable file state + explicit topology/cutover.
+    expect(() => tabOrExactMiddleware({
+      connection: base.connection,
+      sellerPubkey: base.sellerPubkey,
+      network: base.network,
+      perUnit: base.perUnit,
+      ledger: file,
+      ledgerSafetyMode: 'production-single-instance',
+    })).not.toThrow();
+
+    const unusedClient: RedisLikeClient = {
+      get: async () => null,
+      set: async () => 'OK',
+      del: async () => 0,
+      eval: async () => 0,
+    };
+    expect(() => tabMiddleware({
+      ...base,
+      ledger: new RedisChannelLedger(unusedClient, {
+        durability: {
+          persistence: 'aof-always',
+          failover: 'no-data-loss',
+          maxmemoryPolicy: 'noeviction',
+          isolation: 'dedicated-instance',
+        },
+        writerCutover: 'all-legacy-writers-stopped',
+        channelIdCutover: 'legacy-case-aliases-migrated-or-empty',
+      }),
+      ledgerSafetyMode: 'production-multi-instance',
+    })).not.toThrow();
+  });
+
+  it('blocks an upgrade replay when a legacy mixed-case file would be invisible to the lowercase key', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'channel-alias-upgrade-'));
+    const legacyAlias = 'A'.repeat(64);
+    const canonical = legacyAlias.toLowerCase();
+    try {
+      // <=6.0.0-rc.2 accepted this spelling and used it verbatim as the file
+      // name. The signature still verifies after lowercasing because it covers
+      // the decoded 32 bytes, so silently looking only at the lowercase file
+      // would re-grant the alias's delivered amount.
+      await writeFile(join(dir, `${legacyAlias}.json`), JSON.stringify({
+        lastVoucher: null,
+        deliveredCumulativeAtomic: '50000',
+      }));
+      const unmigrated = new FileChannelLedger(dir);
+      expect(await unmigrated.get(canonical)).toBeNull();
+      await expect(unmigrated.get(legacyAlias)).rejects.toThrow(/canonical lowercase/);
+      expect(() => tabMiddleware({
+        ...base,
+        ledger: unmigrated,
+        ledgerSafetyMode: 'production-single-instance',
+      })).toThrow(/channel-id alias migration/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tab/seller/__tests__/middleware-restart-reseed.test.ts
+++ b/src/tab/seller/__tests__/middleware-restart-reseed.test.ts
@@ -100,6 +100,13 @@ function persistedEntry(cumulative: string) {
 
 const mockedEnforceScope = vi.mocked(enforceScope);
 
+async function seedLedger(ledger: InMemoryChannelLedger, cumulative: string): Promise<void> {
+  const lease = await ledger.tryAcquireLease(CHANNEL, 60_000);
+  if (!lease) throw new Error('expected seed lease');
+  await ledger.set(CHANNEL, persistedEntry(cumulative), lease);
+  await ledger.releaseLease(CHANNEL, lease);
+}
+
 describe('restart baseline reseeding from the durable ledger', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -109,7 +116,7 @@ describe('restart baseline reseeding from the durable ledger', () => {
     const ledger = new InMemoryChannelLedger();
     // Lifetime cumulative $1.50 — ABOVE the $1.00 per-voucher cap. Pre-patch,
     // a fresh process treats 1.50→1.51 as a 1.51 increment and 402s.
-    await ledger.set(CHANNEL, persistedEntry(humanToAtomic('1.50')));
+    await seedLedger(ledger, humanToAtomic('1.50'));
 
     const middleware = mw(ledger); // fresh middleware = fresh SessionCache = restarted process
     const { req, res } = fakeReqRes(voucherHeader(CHANNEL, humanToAtomic('1.51'), 8));
@@ -126,7 +133,7 @@ describe('restart baseline reseeding from the durable ledger', () => {
 
   it('still rejects a genuinely oversized increment after reseed', async () => {
     const ledger = new InMemoryChannelLedger();
-    await ledger.set(CHANNEL, persistedEntry(humanToAtomic('1.50')));
+    await seedLedger(ledger, humanToAtomic('1.50'));
 
     const middleware = mw(ledger);
     // 1.50 → 2.90 is a $1.40 single-voucher increment > the $1.00 cap.

--- a/src/tab/seller/__tests__/middleware-v2-reservation.test.ts
+++ b/src/tab/seller/__tests__/middleware-v2-reservation.test.ts
@@ -278,7 +278,9 @@ describe('Native Tab V2 seller reservation admission', () => {
 
     expect(legitimateNext).toHaveBeenCalledOnce();
     expect(mocks.inspectSolanaFinalVoucherV2Reservation).toHaveBeenCalledTimes(2);
-    expect(mocks.enforceScope).toHaveBeenCalledTimes(2);
+    // The legitimate request is checked once before and once after acquiring
+    // the durable lease; the rejected request fails its first scope check.
+    expect(mocks.enforceScope).toHaveBeenCalledTimes(3);
   });
 
   it('does not let a concurrent first-seen registration overwrite the channel winner', async () => {
@@ -350,11 +352,83 @@ describe('Native Tab V2 seller reservation admission', () => {
     expect(winnerRetryNext).toHaveBeenCalledOnce();
   });
 
+  it('revalidates durable registration after lease when a different process wins during proof', async () => {
+    const delayedProof = deferred<ReturnType<typeof chainState>>();
+    mocks.inspectSolanaFinalVoucherV2Reservation
+      .mockImplementationOnce(() => delayedProof.promise)
+      .mockResolvedValueOnce(chainState());
+    const ledger = new InMemoryChannelLedger();
+    const delayedProcess = middleware(ledger).handle;
+    const winningProcess = middleware(ledger).handle; // independent SessionCache
+
+    const delayed = requestResponse(voucherHeader(
+      '5000',
+      0x8000_0001,
+      reservationReceipt(),
+      true,
+      '11'.repeat(188),
+    ));
+    const delayedNext = vi.fn();
+    const delayedPending = delayedProcess(delayed.req, delayed.res, delayedNext);
+    await vi.waitFor(() => {
+      expect(mocks.inspectSolanaFinalVoucherV2Reservation).toHaveBeenCalledTimes(1);
+    });
+
+    const winner = requestResponse(voucherHeader(
+      '5000',
+      0x8000_0001,
+      reservationReceipt(),
+      true,
+      '22'.repeat(188),
+    ));
+    const winnerNext = vi.fn();
+    await winningProcess(winner.req, winner.res, winnerNext);
+    expect(winnerNext).toHaveBeenCalledOnce();
+    await release(winner.res);
+
+    delayedProof.resolve(chainState());
+    await delayedPending;
+    expect(delayedNext).not.toHaveBeenCalled();
+    expect(delayed.res.statusCode).toBe(402);
+    expect(delayed.res.body).toMatchObject({
+      error: 'invalid_voucher',
+      detail: expect.stringContaining('durable channel registration changed'),
+    });
+    expect(Array.from((await ledger.get(CHANNEL))!.lastVoucher!.sessionRegistration))
+      .toEqual(Array.from(new Uint8Array(188).fill(0x22)));
+  });
+
+  it('does not acquire or renew a lease after the response closes during deferred proof', async () => {
+    const delayedProof = deferred<ReturnType<typeof chainState>>();
+    mocks.inspectSolanaFinalVoucherV2Reservation.mockReturnValueOnce(delayedProof.promise);
+    const ledger = new InMemoryChannelLedger();
+    const renew = vi.spyOn(ledger, 'renewLease');
+    const { handle } = middleware(ledger);
+    const response = requestResponse(voucherHeader('5000', 0x8000_0001));
+    const next = vi.fn();
+
+    const pending = handle(response.req, response.res, next);
+    await vi.waitFor(() => {
+      expect(mocks.inspectSolanaFinalVoucherV2Reservation).toHaveBeenCalledOnce();
+    });
+    response.res.emit('close');
+    delayedProof.resolve(chainState());
+    await pending;
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.req.tab).toBeUndefined();
+    expect(renew).not.toHaveBeenCalled();
+    const available = await ledger.tryAcquireLease(CHANNEL, 60_000);
+    expect(available).not.toBeNull();
+    await ledger.releaseLease(CHANNEL, available!);
+  });
+
   it('does not cache a first-seen registration that loses the durable lease', async () => {
     const ledger = new InMemoryChannelLedger();
+    const originalAcquire = ledger.tryAcquireLease.bind(ledger);
     vi.spyOn(ledger, 'tryAcquireLease')
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true);
+      .mockResolvedValueOnce(null)
+      .mockImplementation(originalAcquire);
     const { handle } = middleware(ledger);
 
     const leaseLoser = requestResponse(voucherHeader(

--- a/src/tab/seller/__tests__/redis-channel-ledger.test.ts
+++ b/src/tab/seller/__tests__/redis-channel-ledger.test.ts
@@ -6,13 +6,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { RedisChannelLedger, type RedisLikeClient } from '../redis-channel-ledger';
-import type { ChannelLedgerEntry } from '../channel-ledger';
+import { ChannelLeaseLostError, type ChannelLedgerEntry, type ChannelLease } from '../channel-ledger';
 
 const CHANNEL = 'e'.repeat(64);
 
-/** In-memory fake honoring the exact subset the ledger uses: GET, SET [PX ms] [NX], DEL, EVAL(compare-and-del). */
+/** In-memory fake honoring the exact Redis GET/EVAL scripts the ledger uses. */
 class FakeRedis implements RedisLikeClient {
   store = new Map<string, { value: string; expiresAtMs: number | null }>();
+  evalError: Error | null = null;
 
   private live(key: string): { value: string; expiresAtMs: number | null } | undefined {
     const rec = this.store.get(key);
@@ -47,14 +48,47 @@ class FakeRedis implements RedisLikeClient {
     return n;
   }
 
-  async eval(_script: string, _numKeys: number, ...args: Array<string | number>): Promise<unknown> {
-    // The only script the ledger ships: compare token, delete on match.
-    const [key, token] = args as [string, string];
-    if (this.live(key)?.value === token) {
-      this.store.delete(key);
+  async eval(script: string, numKeys: number, ...args: Array<string | number>): Promise<unknown> {
+    if (this.evalError) throw this.evalError;
+    const keys = args.slice(0, numKeys).map(String);
+    const argv = args.slice(numKeys).map(String);
+
+    if (script.includes('return redis.call("get", KEYS[1])')) {
+      return this.live(keys[0])?.value ?? null;
+    }
+
+    if (script.includes('redis.call("incr"')) {
+      const [leaseKey, fenceKey] = keys;
+      if (this.live(leaseKey)) return false;
+      const fence = BigInt(this.live(fenceKey)?.value ?? '0') + 1n;
+      this.store.set(fenceKey, { value: fence.toString(), expiresAtMs: null });
+      this.store.set(leaseKey, {
+        value: `${argv[0]}:${fence}`,
+        expiresAtMs: Date.now() + Number(argv[1]),
+      });
+      return fence.toString();
+    }
+
+    const [leaseKey, secondKey] = keys;
+    if (this.live(leaseKey)?.value !== argv[0]) return 0;
+    if (script.includes('redis.call("pexpire"')) {
+      const current = this.live(leaseKey)!;
+      this.store.set(leaseKey, {
+        value: current.value,
+        expiresAtMs: Date.now() + Number(argv[1]),
+      });
       return 1;
     }
-    return 0;
+    if (script.includes('redis.call("set", KEYS[2], ARGV[2])')) {
+      this.store.set(secondKey, { value: argv[1], expiresAtMs: null });
+      return 1;
+    }
+    if (script.includes('redis.call("del", KEYS[2])')) {
+      this.store.delete(secondKey);
+      return 1;
+    }
+    this.store.delete(leaseKey);
+    return 1;
   }
 }
 
@@ -82,9 +116,16 @@ describe('RedisChannelLedger', () => {
     vi.useRealTimers();
   });
 
+  async function acquire(ledger: RedisChannelLedger, ttlMs = 5000): Promise<ChannelLease> {
+    const lease = await ledger.tryAcquireLease(CHANNEL, ttlMs);
+    if (!lease) throw new Error('expected Redis lease');
+    return lease;
+  }
+
   it('round-trips an entry with Uint8Array voucher fields intact', async () => {
     const ledger = new RedisChannelLedger(redis);
-    await ledger.set(CHANNEL, entry('150000'));
+    const lease = await acquire(ledger);
+    await ledger.set(CHANNEL, entry('150000'), lease);
     const got = await ledger.get(CHANNEL);
     expect(got).not.toBeNull();
     expect(got!.lastVoucher!.payload.cumulativeAmount).toBe('150000');
@@ -100,50 +141,232 @@ describe('RedisChannelLedger', () => {
     expect(await ledger.get(CHANNEL)).toBeNull();
   });
 
-  it('never persists an inline lease on set', async () => {
+  it('keeps lease identity out of the durable revenue entry', async () => {
     const ledger = new RedisChannelLedger(redis);
-    await ledger.set(CHANNEL, { ...entry('1'), lease: { heldUntilUnixMs: Date.now() + 99999 } });
-    expect(JSON.parse(redis.store.get('tab:ledger:' + CHANNEL)!.value).lease).toBeUndefined();
+    const lease = await acquire(ledger);
+    await ledger.set(CHANNEL, entry('1'), lease);
+    const persisted = JSON.parse(redis.store.get(`tab:ledger:${CHANNEL}`)!.value);
+    expect(persisted.lease).toBeUndefined();
+    expect(JSON.stringify(persisted)).not.toContain(lease.ownerToken);
   });
 
   it('lease is exclusive across instances and reopens after TTL expiry', async () => {
     const a = new RedisChannelLedger(redis);
     const b = new RedisChannelLedger(redis); // second process, same Redis
-    expect(await a.tryAcquireLease(CHANNEL, 5000)).toBe(true);
-    expect(await b.tryAcquireLease(CHANNEL, 5000)).toBe(false);
-    expect(await a.tryAcquireLease(CHANNEL, 5000)).toBe(false); // strict: even the holder re-acquires only after release/expiry
+    const first = await acquire(a);
+    expect(await b.tryAcquireLease(CHANNEL, 5000)).toBeNull();
+    expect(await a.tryAcquireLease(CHANNEL, 5000)).toBeNull(); // strict: even the holder re-acquires only after release/expiry
     vi.advanceTimersByTime(5001);
-    expect(await b.tryAcquireLease(CHANNEL, 5000)).toBe(true);
+    const takeover = await acquire(b);
+    expect(BigInt(takeover.fence)).toBeGreaterThan(BigInt(first.fence));
+  });
+
+  it('rejects invalid TTLs before sending PX or PEXPIRE to Redis', async () => {
+    const ledger = new RedisChannelLedger(redis);
+    await expect(ledger.tryAcquireLease(CHANNEL, NaN)).rejects.toThrow(/lease TTL/);
+    await expect(ledger.tryAcquireLease(CHANNEL, Infinity)).rejects.toThrow(/lease TTL/);
+    const lease = await acquire(ledger);
+    await expect(ledger.renewLease(CHANNEL, lease, 1.5)).rejects.toThrow(/lease TTL/);
+  });
+
+  it('renews only the exact owner/fence without changing its monotonic fence', async () => {
+    const owner = new RedisChannelLedger(redis);
+    const other = new RedisChannelLedger(redis);
+    const lease = await acquire(owner);
+    vi.advanceTimersByTime(4000);
+    const renewed = await owner.renewLease(CHANNEL, lease, 5000);
+    expect(renewed.fence).toBe(lease.fence);
+    expect(renewed.ownerToken).toBe(lease.ownerToken);
+    vi.advanceTimersByTime(2000); // original TTL elapsed; renewed lease lives
+    expect(await other.tryAcquireLease(CHANNEL, 5000)).toBeNull();
+    await expect(
+      other.renewLease(CHANNEL, { ...lease, ownerToken: 'stale' }, 5000),
+    ).rejects.toBeInstanceOf(ChannelLeaseLostError);
   });
 
   it('release only deletes the lease this instance still owns (token guard)', async () => {
     const a = new RedisChannelLedger(redis);
     const b = new RedisChannelLedger(redis);
-    expect(await a.tryAcquireLease(CHANNEL, 5000)).toBe(true);
+    const stale = await acquire(a);
     vi.advanceTimersByTime(5001); // A's lease expires…
-    expect(await b.tryAcquireLease(CHANNEL, 5000)).toBe(true); // …B takes over
-    await a.releaseLease(CHANNEL); // stale A releases — must NOT delete B's lease
+    const current = await acquire(b); // …B takes over
+    expect(await a.releaseLease(CHANNEL, stale)).toBe(false); // stale A releases — must NOT delete B's lease
     const c = new RedisChannelLedger(redis);
-    expect(await c.tryAcquireLease(CHANNEL, 5000)).toBe(false); // B still holds
-    await b.releaseLease(CHANNEL);
-    expect(await c.tryAcquireLease(CHANNEL, 5000)).toBe(true); // real release frees it
+    expect(await c.tryAcquireLease(CHANNEL, 5000)).toBeNull(); // B still holds
+    expect(await b.releaseLease(CHANNEL, current)).toBe(true);
+    expect(await c.tryAcquireLease(CHANNEL, 5000)).not.toBeNull(); // real release frees it
   });
 
   it('releaseLease is a no-op for an instance that never acquired', async () => {
     const a = new RedisChannelLedger(redis);
     const b = new RedisChannelLedger(redis);
-    expect(await a.tryAcquireLease(CHANNEL, 5000)).toBe(true);
-    await b.releaseLease(CHANNEL); // b never held it
-    expect(await b.tryAcquireLease(CHANNEL, 5000)).toBe(false); // a's lease intact
+    const held = await acquire(a);
+    const fabricated = { ...held, ownerToken: 'not-the-owner' };
+    expect(await b.releaseLease(CHANNEL, fabricated)).toBe(false);
+    expect(await b.tryAcquireLease(CHANNEL, 5000)).toBeNull(); // a's lease intact
   });
 
-  it('delete removes both the entry and any lease', async () => {
+  it('delete removes the revenue entry but keeps ownership fenced until explicit release', async () => {
     const ledger = new RedisChannelLedger(redis);
-    await ledger.set(CHANNEL, entry('5'));
-    await ledger.tryAcquireLease(CHANNEL, 60000);
-    await ledger.delete(CHANNEL);
+    const lease = await acquire(ledger, 60_000);
+    await ledger.set(CHANNEL, entry('5'), lease);
+    await ledger.delete(CHANNEL, lease);
     expect(await ledger.get(CHANNEL)).toBeNull();
+    await ledger.releaseLease(CHANNEL, lease);
     const other = new RedisChannelLedger(redis);
-    expect(await other.tryAcquireLease(CHANNEL, 5000)).toBe(true); // lease gone too
+    expect(await other.tryAcquireLease(CHANNEL, 5000)).not.toBeNull();
+  });
+
+  it('conditionally rejects a stale writer after TTL crash takeover', async () => {
+    const crashed = new RedisChannelLedger(redis);
+    const stale = await acquire(crashed);
+    await crashed.set(CHANNEL, entry('1'), stale);
+    vi.advanceTimersByTime(5001);
+
+    const restarted = new RedisChannelLedger(redis);
+    const takeover = await acquire(restarted);
+    await restarted.set(CHANNEL, entry('2'), takeover);
+    await expect(crashed.set(CHANNEL, entry('999'), stale))
+      .rejects.toBeInstanceOf(ChannelLeaseLostError);
+    expect((await restarted.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('2');
+    expect(BigInt(takeover.fence)).toBeGreaterThan(BigInt(stale.fence));
+  });
+
+  it('survives an adapter restart and never resets the Redis fence', async () => {
+    const before = new RedisChannelLedger(redis);
+    const first = await acquire(before);
+    await before.set(CHANNEL, entry('7'), first);
+    await before.releaseLease(CHANNEL, first);
+
+    const after = new RedisChannelLedger(redis);
+    expect((await after.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('7');
+    const second = await acquire(after);
+    expect(BigInt(second.fence)).toBeGreaterThan(BigInt(first.fence));
+  });
+
+  it('does not advertise restart safety without explicit durable/noeviction attestation', () => {
+    expect(new RedisChannelLedger(redis).capabilities).toMatchObject({
+      restartSafe: false,
+      canonicalChannelIds: false,
+    });
+    expect(new RedisChannelLedger(redis, {
+      durability: {
+        persistence: 'aof-always',
+        failover: 'no-data-loss',
+        maxmemoryPolicy: 'noeviction',
+        isolation: 'dedicated-instance',
+      },
+    }).capabilities.restartSafe).toBe(false);
+    const durable = new RedisChannelLedger(redis, {
+      durability: {
+        persistence: 'aof-always',
+        failover: 'no-data-loss',
+        maxmemoryPolicy: 'noeviction',
+        isolation: 'dedicated-instance',
+      },
+      writerCutover: 'all-legacy-writers-stopped',
+      channelIdCutover: 'legacy-case-aliases-migrated-or-empty',
+    });
+    expect(durable.capabilities).toMatchObject({
+      restartSafe: true,
+      multiInstanceSafe: true,
+      canonicalChannelIds: true,
+    });
+    expect(() => new RedisChannelLedger(redis, {
+      durability: {} as any,
+    })).toThrow(/durability attestation must confirm/);
+    expect(() => new RedisChannelLedger(redis, {
+      durability: null as any,
+    })).toThrow(/durability attestation must confirm/);
+    expect(() => new RedisChannelLedger(redis, {
+      channelIdCutover: 'wrong' as any,
+    })).toThrow(/channelIdCutover/);
+  });
+
+  it('rejects uppercase before any Redis key or lock alias can be created', async () => {
+    const ledger = new RedisChannelLedger(redis, {
+      channelIdCutover: 'legacy-case-aliases-migrated-or-empty',
+    });
+    await expect(ledger.get('E'.repeat(64))).rejects.toThrow(/canonical lowercase/);
+    await expect(ledger.tryAcquireLease('E'.repeat(64), 5_000))
+      .rejects.toThrow(/canonical lowercase/);
+    expect(redis.store.size).toBe(0);
+  });
+
+  it('uses one Redis Cluster hash tag for ledger, lease, and fence keys', async () => {
+    const ledger = new RedisChannelLedger(redis, {
+      keyLayout: 'cluster-v1',
+      keyspaceCutover: 'legacy-state-migrated-or-empty',
+    });
+    const lease = await acquire(ledger);
+    await ledger.set(CHANNEL, entry('1'), lease);
+    const keys = [...redis.store.keys()].filter((key) => key.includes(CHANNEL));
+    expect(keys).toEqual(expect.arrayContaining([
+      `tab:{${CHANNEL}}:ledger`,
+      `tab:{${CHANNEL}}:lease`,
+      `tab:{${CHANNEL}}:fence`,
+    ]));
+    expect(new Set(keys.map((key) => key.match(/\{[^}]+\}/)?.[0])).size).toBe(1);
+  });
+
+  it('preserves the legacy ledger/lease namespace and waits on a raw old UUID lease', async () => {
+    const legacyEntry = JSON.stringify({
+      ...entry('41'),
+      lastVoucher: {
+        ...entry('41').lastVoucher,
+        sessionPublicKey: Buffer.from(entry('41').lastVoucher!.sessionPublicKey).toString('hex'),
+        sessionRegistration: Buffer.from(entry('41').lastVoucher!.sessionRegistration).toString('hex'),
+        sessionSignature: Buffer.from(entry('41').lastVoucher!.sessionSignature).toString('hex'),
+      },
+    });
+    redis.store.set(`tab:ledger:${CHANNEL}`, { value: legacyEntry, expiresAtMs: null });
+    redis.store.set(`tab:lease:${CHANNEL}`, {
+      value: 'old-sdk-raw-uuid-token',
+      expiresAtMs: Date.now() + 5_000,
+    });
+
+    const upgraded = new RedisChannelLedger(redis);
+    expect((await upgraded.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('41');
+    expect(await upgraded.tryAcquireLease(CHANNEL, 5_000)).toBeNull();
+    expect(redis.store.has(`tab:{${CHANNEL}}:ledger`)).toBe(false);
+  });
+
+  it('requires explicit cluster cutover and rejects every legacy key remnant', async () => {
+    expect(() => new RedisChannelLedger(redis, {
+      keyLayout: 'cluster-v1',
+    })).toThrow(/keyspaceCutover/);
+
+    const cluster = new RedisChannelLedger(redis, {
+      keyLayout: 'cluster-v1',
+      keyspaceCutover: 'legacy-state-migrated-or-empty',
+    });
+    for (const suffix of ['ledger', 'lease', 'fence'] as const) {
+      redis.store.clear();
+      redis.store.set(`tab:${suffix}:${CHANNEL}`, { value: 'legacy', expiresAtMs: null });
+      await expect(cluster.get(CHANNEL)).rejects.toThrow(/legacy Redis seller state exists/);
+    }
+  });
+
+  it('forces reads through primary-routed Lua instead of a possibly stale client GET', async () => {
+    const ledger = new RedisChannelLedger(redis);
+    const lease = await acquire(ledger);
+    await ledger.set(CHANNEL, entry('9'), lease);
+    const replicaGet = vi.spyOn(redis, 'get').mockResolvedValue(null);
+    expect((await ledger.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('9');
+    await ledger.update(CHANNEL, lease, (current) => ({
+      ...current!,
+      deliveredCumulativeAtomic: '10',
+    }));
+    expect((await ledger.get(CHANNEL))?.deliveredCumulativeAtomic).toBe('10');
+    expect(replicaGet).not.toHaveBeenCalled();
+  });
+
+  it('propagates Redis write errors without a memory fallback', async () => {
+    const ledger = new RedisChannelLedger(redis);
+    const lease = await acquire(ledger);
+    redis.evalError = new Error('redis unavailable');
+    await expect(ledger.set(CHANNEL, entry('1'), lease)).rejects.toThrow('redis unavailable');
+    redis.evalError = null;
+    expect(await ledger.get(CHANNEL)).toBeNull();
   });
 });

--- a/src/tab/seller/channel-ledger.ts
+++ b/src/tab/seller/channel-ledger.ts
@@ -23,14 +23,14 @@
  * defense against the concurrent-same-channel over-delivery rug. The default
  * InMemoryChannelLedger / FileChannelLedger acquire it atomically WITHIN one
  * seller process (via the per-channel async lock). A seller running MULTIPLE
- * instances behind a load balancer MUST either back ChannelLedger with a store
- * that makes acquire atomic across processes (Redis `SET NX PX`, Postgres
- * advisory lock / `INSERT ... ON CONFLICT`) or route a channel's requests to a
- * consistent instance — otherwise two instances can each acquire the lease and
- * the rug reopens.
+ * instances behind a load balancer MUST back ChannelLedger with a store that
+ * makes acquisition and every owner/fence mutation atomic across processes
+ * (Redis Lua, a versioned Postgres row, etc.). Routing affinity alone is not a
+ * takeover fence and is rejected by `production-multi-instance` safety mode.
  */
 
 import { promises as fs } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { join, dirname } from 'node:path';
 
 import type { AtomicAmount, SignedVoucher } from '../types';
@@ -65,10 +65,9 @@ export interface OnChainLedgerSnapshot {
 export interface ChannelLedgerEntry {
   /**
    * Latest accepted voucher (`payload.cumulativeAmount` is the signedCumulative),
-   * or `null` for a lease-only entry created when the first request on a channel
-   * acquires its single-stream lease BEFORE any voucher is persisted. The
-   * middleware writes the real voucher immediately after acquiring the lease, so
-   * a null `lastVoucher` is only ever a transient pre-first-voucher state.
+   * or `null` for explicitly bootstrapped/legacy entries. Lease identity lives
+   * outside the revenue entry so acquiring a lease never fabricates ledger
+   * history and callers cannot mutate ownership by spreading an entry.
    */
   lastVoucher: SignedVoucher | null;
   /**
@@ -82,7 +81,7 @@ export interface ChannelLedgerEntry {
    * crystallization cadence fires when `deliveredCumulativeAtomic −
    * lastCrystallizedCumulativeAtomic` crosses the configured threshold, then
    * advances this on a successful lock so it can't double-fire. Treated as
-   * `'0'` when absent (older entries / lease-only entries). Optional so
+   * `'0'` when absent (older/bootstrap entries). Optional so
    * pre-Step-4 ledger constructors remain valid without a breaking change.
    */
   lastCrystallizedCumulativeAtomic?: AtomicAmount;
@@ -99,65 +98,230 @@ export interface ChannelLedgerEntry {
   gateRefusedCumulativeAtomic?: AtomicAmount;
   /** RESERVED (Step 4): on-chain money ledger snapshot. Unset today. */
   onChain?: OnChainLedgerSnapshot;
-  /**
-   * Active-stream lease. Set while a meter is live on this channel; cleared on
-   * the meter's terminal path. `heldUntilUnixMs` is a TTL so a crashed holder's
-   * lease auto-expires (a stuck lease would otherwise block the buyer's own
-   * next request on this tab). Enforces one live stream per channel — the
-   * defense against the concurrent-same-channel over-delivery rug.
-   */
-  lease?: { heldUntilUnixMs: number };
 }
 
+/**
+ * Capability returned by lease acquisition and required by every mutation.
+ * `ownerToken` prevents one process from releasing another's lease; `fence`
+ * increases on every successful acquisition so an expired/crashed holder can
+ * never write after a takeover, even if it wakes back up later.
+ */
+export interface ChannelLease {
+  ownerToken: string;
+  /** Canonical unsigned decimal. A string avoids losing Redis INCR precision. */
+  fence: string;
+  heldUntilUnixMs: number;
+}
+
+/** Public safety declaration for a ChannelLedger adapter. */
+export interface ChannelLedgerCapabilities {
+  adapter: 'memory' | 'file' | 'redis' | 'custom';
+  /** Ledger entries and fence counters survive a process restart. */
+  restartSafe: boolean;
+  /** Lease acquisition and fenced writes are atomic across seller processes. */
+  multiInstanceSafe: boolean;
+  /** Every mutation is conditional on owner token + monotonic fence. */
+  conditionalWrites: true;
+  /**
+   * All historical case aliases have been merged into canonical lowercase
+   * channel keys (or the durable store was proven empty before first use).
+   */
+  canonicalChannelIds: boolean;
+}
+
+export type ChannelIdCutover = 'legacy-case-aliases-migrated-or-empty';
+
+export interface FileChannelLedgerOptions {
+  /** Explicit operator acknowledgement after the documented alias migration. */
+  channelIdCutover?: ChannelIdCutover;
+}
+
+export class ChannelLeaseLostError extends Error {
+  readonly code = 'channel_lease_lost';
+
+  constructor(channelId: string) {
+    super(`channel lease lost for ${channelId}`);
+    this.name = 'ChannelLeaseLostError';
+  }
+}
+
+export type ChannelLedgerUpdater = (
+  current: ChannelLedgerEntry | null,
+) => ChannelLedgerEntry;
+
 export interface ChannelLedger {
+  /**
+   * All methods must reject noncanonical channel IDs before taking an adapter
+   * lock or touching storage. `canonicalChannelIds=true` additionally attests
+   * that historical durable aliases were merged or the store was proven empty.
+   */
+  readonly capabilities: ChannelLedgerCapabilities;
   get(channelId: string): Promise<ChannelLedgerEntry | null>;
-  set(channelId: string, entry: ChannelLedgerEntry): Promise<void>;
-  delete(channelId: string): Promise<void>;
+  set(channelId: string, entry: ChannelLedgerEntry, lease: ChannelLease): Promise<void>;
+  /** Atomic within this adapter instance; the resulting write is lease-fenced. */
+  update(
+    channelId: string,
+    lease: ChannelLease,
+    updater: ChannelLedgerUpdater,
+  ): Promise<ChannelLedgerEntry>;
+  delete(channelId: string, lease: ChannelLease): Promise<void>;
   /**
    * Atomically acquire the channel's single-stream lease if free or expired.
-   * Returns true if acquired, false if another live stream holds it. The
+   * Returns a new owner token + monotonically increasing fence if acquired,
+   * or null if another live stream holds it. The
    * in-process/file impls serialize via the per-channel lock (correct for a
    * single seller process). A multi-instance seller MUST back this with a store
-   * that makes acquire atomic across processes (Redis SETNX, Postgres, ...).
+   * that makes acquisition and fenced writes atomic across processes.
    */
-  tryAcquireLease(channelId: string, ttlMs: number): Promise<boolean>;
-  /** Release the channel's lease (no-op if not held). */
-  releaseLease(channelId: string): Promise<void>;
+  tryAcquireLease(channelId: string, ttlMs: number): Promise<ChannelLease | null>;
+  /** Extend this exact live owner/fence lease; stale owners are rejected. */
+  renewLease(
+    channelId: string,
+    lease: ChannelLease,
+    ttlMs: number,
+  ): Promise<ChannelLease>;
+  /** Conditional release. Returns false when this is a stale/non-owner lease. */
+  releaseLease(channelId: string, lease: ChannelLease): Promise<boolean>;
+}
+
+/**
+ * Normalize the lease TTL shared by adapters and middleware. Node timers clamp
+ * values above a signed 32-bit millisecond delay, while NaN/fractions can make
+ * store expiry semantics adapter-dependent. Reject them instead of silently
+ * creating a near-zero or effectively immortal lease.
+ *
+ * @internal
+ */
+export function normalizeLeaseTtlMs(ttlMs: number): number {
+  if (!Number.isSafeInteger(ttlMs) || ttlMs < 3 || ttlMs > 0x7fff_ffff) {
+    throw new Error('channel lease TTL must be an integer from 3 to 2147483647 milliseconds');
+  }
+  return ttlMs;
+}
+
+/** @internal Enforce one key identity before any adapter lock or store access. */
+export function assertCanonicalChannelId(channelId: string): void {
+  if (!/^[0-9a-f]{64}$/.test(channelId)) {
+    throw new Error('channelId must be canonical lowercase 64-character hex');
+  }
+}
+
+function sameLease(left: ChannelLease | undefined, right: ChannelLease): boolean {
+  return left !== undefined
+    && left.ownerToken === right.ownerToken
+    && left.fence === right.fence;
+}
+
+function requireLiveLease(
+  channelId: string,
+  current: ChannelLease | undefined,
+  expected: ChannelLease,
+): void {
+  if (!current || !sameLease(current, expected) || current.heldUntilUnixMs <= Date.now()) {
+    throw new ChannelLeaseLostError(channelId);
+  }
 }
 
 // ── In-memory ledger (zero-config default; loses state on restart) ──────
 
 export class InMemoryChannelLedger implements ChannelLedger {
+  readonly capabilities: ChannelLedgerCapabilities = {
+    adapter: 'memory',
+    restartSafe: false,
+    multiInstanceSafe: false,
+    conditionalWrites: true,
+    // Process-local state cannot survive an upgrade with legacy aliases; all
+    // admitted IDs in this process already passed lowercase middleware.
+    canonicalChannelIds: true,
+  };
+
   private map = new Map<string, ChannelLedgerEntry>();
+  private leases = new Map<string, ChannelLease>();
+  private fences = new Map<string, bigint>();
 
   async get(channelId: string): Promise<ChannelLedgerEntry | null> {
-    return this.map.get(channelId) ?? null;
+    assertCanonicalChannelId(channelId);
+    const entry = this.map.get(channelId);
+    return entry ? deserialize(serialize(entry)) : null;
   }
 
-  async set(channelId: string, entry: ChannelLedgerEntry): Promise<void> {
-    this.map.set(channelId, entry);
+  async set(channelId: string, entry: ChannelLedgerEntry, lease: ChannelLease): Promise<void> {
+    assertCanonicalChannelId(channelId);
+    await withChannelLock(channelId, async () => {
+      requireLiveLease(channelId, this.leases.get(channelId), lease);
+      this.map.set(channelId, deserialize(serialize(entry)));
+    });
   }
 
-  async delete(channelId: string): Promise<void> {
-    this.map.delete(channelId);
-  }
-
-  async tryAcquireLease(channelId: string, ttlMs: number): Promise<boolean> {
+  async update(
+    channelId: string,
+    lease: ChannelLease,
+    updater: ChannelLedgerUpdater,
+  ): Promise<ChannelLedgerEntry> {
+    assertCanonicalChannelId(channelId);
     return withChannelLock(channelId, async () => {
-      const cur = this.map.get(channelId);
+      requireLiveLease(channelId, this.leases.get(channelId), lease);
+      const current = this.map.get(channelId);
+      const next = updater(current ? deserialize(serialize(current)) : null);
+      const stored = deserialize(serialize(next));
+      this.map.set(channelId, stored);
+      return deserialize(serialize(stored));
+    });
+  }
+
+  async delete(channelId: string, lease: ChannelLease): Promise<void> {
+    assertCanonicalChannelId(channelId);
+    await withChannelLock(channelId, async () => {
+      requireLiveLease(channelId, this.leases.get(channelId), lease);
+      this.map.delete(channelId);
+    });
+  }
+
+  async tryAcquireLease(channelId: string, ttlMs: number): Promise<ChannelLease | null> {
+    assertCanonicalChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const ttl = normalizeLeaseTtlMs(ttlMs);
       const now = Date.now();
-      if (cur?.lease && cur.lease.heldUntilUnixMs > now) return false; // held & unexpired
-      const base: ChannelLedgerEntry =
-        cur ?? { lastVoucher: null, deliveredCumulativeAtomic: '0', lastCrystallizedCumulativeAtomic: '0' };
-      this.map.set(channelId, { ...base, lease: { heldUntilUnixMs: now + ttlMs } });
+      const current = this.leases.get(channelId);
+      if (current && current.heldUntilUnixMs > now) return null;
+      const nextFence = (this.fences.get(channelId) ?? 0n) + 1n;
+      this.fences.set(channelId, nextFence);
+      const lease: ChannelLease = {
+        ownerToken: randomUUID(),
+        fence: nextFence.toString(),
+        heldUntilUnixMs: now + ttl,
+      };
+      this.leases.set(channelId, lease);
+      return { ...lease };
+    });
+  }
+
+  async releaseLease(channelId: string, lease: ChannelLease): Promise<boolean> {
+    assertCanonicalChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const current = this.leases.get(channelId);
+      if (!current || !sameLease(current, lease) || current.heldUntilUnixMs <= Date.now()) return false;
+      this.leases.delete(channelId);
       return true;
     });
   }
 
-  async releaseLease(channelId: string): Promise<void> {
-    await withChannelLock(channelId, async () => {
-      const cur = this.map.get(channelId);
-      if (cur) this.map.set(channelId, { ...cur, lease: undefined });
+  async renewLease(
+    channelId: string,
+    lease: ChannelLease,
+    ttlMs: number,
+  ): Promise<ChannelLease> {
+    assertCanonicalChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const ttl = normalizeLeaseTtlMs(ttlMs);
+      const current = this.leases.get(channelId);
+      requireLiveLease(channelId, current, lease);
+      const renewed: ChannelLease = {
+        ...current!,
+        heldUntilUnixMs: Date.now() + ttl,
+      };
+      this.leases.set(channelId, renewed);
+      return { ...renewed };
     });
   }
 }
@@ -177,7 +341,6 @@ export interface SerializedEntry {
   lastCrystallizedCumulativeAtomic?: AtomicAmount;
   gateRefusedCumulativeAtomic?: AtomicAmount;
   onChain?: OnChainLedgerSnapshot;
-  lease?: { heldUntilUnixMs: number };
 }
 
 function bytesToHex(b: Uint8Array): string {
@@ -215,7 +378,6 @@ function serialize(entry: ChannelLedgerEntry): SerializedEntry {
     lastCrystallizedCumulativeAtomic: entry.lastCrystallizedCumulativeAtomic,
     gateRefusedCumulativeAtomic: entry.gateRefusedCumulativeAtomic,
     onChain: entry.onChain,
-    lease: entry.lease,
   };
 }
 
@@ -233,28 +395,69 @@ function deserialize(s: SerializedEntry): ChannelLedgerEntry {
     lastCrystallizedCumulativeAtomic: s.lastCrystallizedCumulativeAtomic ?? '0',
     gateRefusedCumulativeAtomic: s.gateRefusedCumulativeAtomic,
     onChain: s.onChain,
-    lease: s.lease,
   };
 }
 
 // ── File-backed ledger (durable across restarts; one JSON file per channel) ──
 //
-// Atomicity matches FileVoucherStore: write-then-rename. The middleware
-// serializes writes per channel, so concurrent same-channel writes don't race
-// in practice. Production sellers expecting high concurrency implement
-// ChannelLedger over Redis/Postgres and pass it into tabMiddleware.
+// Atomicity matches FileVoucherStore: write-then-rename. Adapter mutations are
+// serialized per channel and require the current owner token + fence. This is
+// restart-safe but deliberately declares multiInstanceSafe=false: separate OS
+// processes do not share the in-process lock. Use Redis/Postgres for that.
 
 export class FileChannelLedger implements ChannelLedger {
-  constructor(private readonly dir: string) {}
+  readonly capabilities: ChannelLedgerCapabilities;
 
-  private pathFor(channelId: string): string {
-    if (!/^[a-z0-9_-]+$/i.test(channelId)) {
-      throw new Error(`unsafe channelId for filesystem: ${channelId}`);
+  constructor(
+    private readonly dir: string,
+    options: FileChannelLedgerOptions = {},
+  ) {
+    if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+      throw new Error('FileChannelLedger options must be an object');
     }
-    return join(this.dir, `${channelId}.json`);
+    if (
+      options.channelIdCutover !== undefined
+      && options.channelIdCutover !== 'legacy-case-aliases-migrated-or-empty'
+    ) {
+      throw new Error('invalid FileChannelLedger channelIdCutover acknowledgement');
+    }
+    this.capabilities = {
+      adapter: 'file',
+      restartSafe: true,
+      multiInstanceSafe: false,
+      conditionalWrites: true,
+      canonicalChannelIds:
+        options.channelIdCutover === 'legacy-case-aliases-migrated-or-empty',
+    };
+  }
+
+  private pathFor(channelId: string, suffix = '.json'): string {
+    assertCanonicalChannelId(channelId);
+    return join(this.dir, `${channelId}${suffix}`);
+  }
+
+  private async writeAtomic(path: string, value: string): Promise<void> {
+    await fs.mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.${randomUUID()}.tmp`;
+    await fs.writeFile(tmp, value);
+    await fs.rename(tmp, path);
+  }
+
+  private async readLease(channelId: string): Promise<ChannelLease | undefined> {
+    try {
+      return JSON.parse(await fs.readFile(this.pathFor(channelId, '.lease.json'), 'utf8')) as ChannelLease;
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') return undefined;
+      throw error;
+    }
+  }
+
+  private async requireLease(channelId: string, lease: ChannelLease): Promise<void> {
+    requireLiveLease(channelId, await this.readLease(channelId), lease);
   }
 
   async get(channelId: string): Promise<ChannelLedgerEntry | null> {
+    assertCanonicalChannelId(channelId);
     try {
       const raw = await fs.readFile(this.pathFor(channelId), 'utf8');
       return deserialize(JSON.parse(raw) as SerializedEntry);
@@ -264,38 +467,96 @@ export class FileChannelLedger implements ChannelLedger {
     }
   }
 
-  async set(channelId: string, entry: ChannelLedgerEntry): Promise<void> {
-    const path = this.pathFor(channelId);
-    await fs.mkdir(dirname(path), { recursive: true });
-    const tmp = `${path}.tmp`;
-    await fs.writeFile(tmp, JSON.stringify(serialize(entry)));
-    await fs.rename(tmp, path);
+  async set(channelId: string, entry: ChannelLedgerEntry, lease: ChannelLease): Promise<void> {
+    assertCanonicalChannelId(channelId);
+    await withChannelLock(channelId, async () => {
+      await this.requireLease(channelId, lease);
+      await this.writeAtomic(this.pathFor(channelId), JSON.stringify(serialize(entry)));
+    });
   }
 
-  async delete(channelId: string): Promise<void> {
-    try {
-      await fs.unlink(this.pathFor(channelId));
-    } catch (e: any) {
-      if (e?.code !== 'ENOENT') throw e;
-    }
-  }
-
-  async tryAcquireLease(channelId: string, ttlMs: number): Promise<boolean> {
+  async update(
+    channelId: string,
+    lease: ChannelLease,
+    updater: ChannelLedgerUpdater,
+  ): Promise<ChannelLedgerEntry> {
+    assertCanonicalChannelId(channelId);
     return withChannelLock(channelId, async () => {
-      const cur = await this.get(channelId);
+      await this.requireLease(channelId, lease);
+      const next = updater(await this.get(channelId));
+      await this.writeAtomic(this.pathFor(channelId), JSON.stringify(serialize(next)));
+      return next;
+    });
+  }
+
+  async delete(channelId: string, lease: ChannelLease): Promise<void> {
+    assertCanonicalChannelId(channelId);
+    await withChannelLock(channelId, async () => {
+      await this.requireLease(channelId, lease);
+      try {
+        await fs.unlink(this.pathFor(channelId));
+      } catch (error: any) {
+        if (error?.code !== 'ENOENT') throw error;
+      }
+    });
+  }
+
+  async tryAcquireLease(channelId: string, ttlMs: number): Promise<ChannelLease | null> {
+    assertCanonicalChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const ttl = normalizeLeaseTtlMs(ttlMs);
       const now = Date.now();
-      if (cur?.lease && cur.lease.heldUntilUnixMs > now) return false;
-      const base: ChannelLedgerEntry =
-        cur ?? { lastVoucher: null, deliveredCumulativeAtomic: '0', lastCrystallizedCumulativeAtomic: '0' };
-      await this.set(channelId, { ...base, lease: { heldUntilUnixMs: now + ttlMs } });
+      const current = await this.readLease(channelId);
+      if (current && current.heldUntilUnixMs > now) return null;
+      let currentFence = 0n;
+      try {
+        currentFence = BigInt(await fs.readFile(this.pathFor(channelId, '.fence'), 'utf8'));
+      } catch (error: any) {
+        if (error?.code !== 'ENOENT') throw error;
+      }
+      const fence = currentFence + 1n;
+      // Persist the counter before the lease. A crash can skip a number but can
+      // never reuse one, which is the only safe direction for a fence.
+      await this.writeAtomic(this.pathFor(channelId, '.fence'), fence.toString());
+      const lease: ChannelLease = {
+        ownerToken: randomUUID(),
+        fence: fence.toString(),
+        heldUntilUnixMs: now + ttl,
+      };
+      await this.writeAtomic(this.pathFor(channelId, '.lease.json'), JSON.stringify(lease));
+      return lease;
+    });
+  }
+
+  async releaseLease(channelId: string, lease: ChannelLease): Promise<boolean> {
+    assertCanonicalChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const current = await this.readLease(channelId);
+      if (!current || !sameLease(current, lease) || current.heldUntilUnixMs <= Date.now()) return false;
+      await fs.unlink(this.pathFor(channelId, '.lease.json'));
       return true;
     });
   }
 
-  async releaseLease(channelId: string): Promise<void> {
-    await withChannelLock(channelId, async () => {
-      const cur = await this.get(channelId);
-      if (cur) await this.set(channelId, { ...cur, lease: undefined });
+  async renewLease(
+    channelId: string,
+    lease: ChannelLease,
+    ttlMs: number,
+  ): Promise<ChannelLease> {
+    assertCanonicalChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const ttl = normalizeLeaseTtlMs(ttlMs);
+      const current = await this.readLease(channelId);
+      requireLiveLease(channelId, current, lease);
+      const renewed: ChannelLease = {
+        ...current!,
+        heldUntilUnixMs: Date.now() + ttl,
+      };
+      await this.writeAtomic(
+        this.pathFor(channelId, '.lease.json'),
+        JSON.stringify(renewed),
+      );
+      return renewed;
     });
   }
 }

--- a/src/tab/seller/dual.ts
+++ b/src/tab/seller/dual.ts
@@ -42,6 +42,12 @@ export interface TabOrExactConfig {
   perUnit: HumanAmount;
   facilitatorUrl?: string;
   description?: string;
+  /** Durable seller-owned tab ledger. Required by production safety modes. */
+  ledger?: TabMiddlewareOptions['ledger'];
+  /** See TabMiddlewareOptions. Explicit outside exact test/development NODE_ENV. */
+  ledgerSafetyMode?: TabMiddlewareOptions['ledgerSafetyMode'];
+  /** Maximum stream lease duration before crash takeover is permitted. */
+  leaseTtlMs?: TabMiddlewareOptions['leaseTtlMs'];
   /**
    * Keyless crystallization cadence for the tab rail — forwarded verbatim to
    * `tabMiddleware` (see `TabMiddlewareOptions.lockCadence`). This is the
@@ -95,6 +101,9 @@ export function tabOrExactMiddleware(config: TabOrExactConfig): RequestHandler {
     perUnit: config.perUnit,
     settle: 'on-close',
     facilitatorUrl: config.facilitatorUrl,
+    ledger: config.ledger,
+    ledgerSafetyMode: config.ledgerSafetyMode,
+    leaseTtlMs: config.leaseTtlMs,
     lockCadence: config.lockCadence,
   });
 

--- a/src/tab/seller/index.ts
+++ b/src/tab/seller/index.ts
@@ -7,10 +7,22 @@
  *
  * @example
  * ```ts
- * import { tabMiddleware, openSse, requireTab } from '@dexterai/x402/tab/seller';
+ * import {
+ *   FileChannelLedger,
+ *   tabMiddleware,
+ *   openSse,
+ *   requireTab,
+ * } from '@dexterai/x402/tab/seller';
  * import { Connection } from '@solana/web3.js';
  *
  * const connection = new Connection(process.env.RPC!);
+ * const ledgerDir = process.env.TAB_LEDGER_DIR;
+ * const channelIdCutover = process.env.TAB_CHANNEL_ID_CUTOVER;
+ * if (!ledgerDir) throw new Error('TAB_LEDGER_DIR must name persistent storage');
+ * if (channelIdCutover !== 'legacy-case-aliases-migrated-or-empty') {
+ *   throw new Error('prove the store empty or complete the documented alias migration first');
+ * }
+ * const ledger = new FileChannelLedger(ledgerDir, { channelIdCutover });
  * app.post('/inference',
  *   tabMiddleware({
  *     connection,
@@ -18,6 +30,8 @@
  *     perUnit: '0.00003',
  *     network: 'solana:mainnet',
  *     settle: 'on-close',
+ *     ledger,
+ *     ledgerSafetyMode: 'production-single-instance',
  *   }),
  *   async (req, res) => {
  *     const tab = requireTab(req);
@@ -44,27 +58,41 @@ export { InvalidVoucherError } from './types';
 
 // Durable per-channel ledger (off-chain deliveredCumulative + last voucher).
 //
-// Single-stream lease (multi-instance boundary): the default in-memory/file
-// ledger enforces the per-channel single-stream lease correctly WITHIN ONE
-// seller process. Sellers running multiple instances behind a load balancer
-// must back ChannelLedger with a store providing atomic lease acquisition
-// (Redis `SET NX PX`, Postgres advisory lock / `INSERT ON CONFLICT`), or route
-// a channel's requests to a consistent instance — otherwise concurrent
-// same-channel streams can over-deliver across instances.
+// Every adapter declares restartSafe/multiInstanceSafe and must condition every
+// mutation/release on the acquired owner token + monotonic fence. InMemory is
+// development-only; File is restart-safe for one seller process; Redis provides
+// multi-instance fencing and becomes restart-safe only with the explicit
+// verified durability + stopped-legacy-writer attestations. tabMiddleware's
+// production safety modes reject weaker adapters instead of silently falling
+// back.
 export type {
   ChannelLedger,
   ChannelLedgerEntry,
+  ChannelLedgerCapabilities,
+  ChannelLedgerUpdater,
+  ChannelLease,
+  ChannelIdCutover,
+  FileChannelLedgerOptions,
   OnChainLedgerSnapshot,
 } from './channel-ledger';
 export {
+  ChannelLeaseLostError,
   InMemoryChannelLedger,
   FileChannelLedger,
   serializeChannelLedgerEntry,
   deserializeChannelLedgerEntry,
 } from './channel-ledger';
 export type { SerializedEntry } from './channel-ledger';
-export { RedisChannelLedger } from './redis-channel-ledger';
-export type { RedisLikeClient } from './redis-channel-ledger';
+export {
+  RedisChannelLedger,
+  RedisKeyspaceMigrationRequiredError,
+} from './redis-channel-ledger';
+export type {
+  RedisLikeClient,
+  RedisDurabilityAttestation,
+  RedisChannelLedgerOptions,
+  RedisKeyLayout,
+} from './redis-channel-ledger';
 
 // Middleware + helpers.
 export {

--- a/src/tab/seller/meter.ts
+++ b/src/tab/seller/meter.ts
@@ -13,7 +13,7 @@
  *       await meter.charge();          // demand voucher; throws if cap exceeded
  *       meter.send(token);              // emit SSE event with the token
  *     }
- *     meter.end();
+ *     await meter.end();
  *   });
  *
  * NOTE on voucher cadence: this implementation treats EACH `charge()` as
@@ -27,15 +27,10 @@
  * the whole request" model, which is correct for any reasonable chunk
  * count under a single per-request increment.
  *
- * Concurrency note: delivered accounting is exact for requests that run
- * sequentially per channel (the normal case — an agent streams one request at
- * a time per tab). Two GENUINELY concurrent streams on the SAME channel each
- * read the same delivered baseline, so they can over-deliver in-flight up to
- * the sum of their budgets before either persists. The lifetime ledger stays
- * correct (additive under a per-channel lock), so the over-delivery is bounded
- * to the overlap and never compounds across future requests. Sellers needing
- * exact metering under parallel same-channel streams should serialize requests
- * per channel.
+ * Concurrency note: tabMiddleware holds one renewable fenced lease per channel,
+ * so a second same-channel stream is rejected before it can share a stale
+ * delivered baseline. Production multi-instance sellers must select the
+ * corresponding safety mode and a cross-process adapter such as Redis.
  */
 
 import type { Response } from 'express';
@@ -75,65 +70,68 @@ export function openSse(res: Response, options: OpenSseOptions): SseMeter {
     ? BigInt(humanToAtomic(options.perUnit))
     : null;
 
-  // Cumulative delivered DURING this request (resets per request, as before).
+  // Cumulative write-ahead delivery reservations DURING this request.
   let chargedAtomic = 0n;
   let ended = false;
+  let pendingCharges = 0;
+  let chargeTail: Promise<void> = Promise.resolve();
 
-  // Persist the lifetime delivered cumulative (baseline + this request's
-  // delivery) to the ledger. Called on EVERY terminal path — clean end,
-  // cap-exceeded, AND client disconnect/abort — so a buyer CANNOT grief the
-  // seller by consuming service then dropping the connection before end()
-  // (that would otherwise leave delivered un-advanced and re-grant the budget
-  // next request — a quadratic giveaway). The only unpersisted window left is a
-  // hard process crash: not buyer-controllable, bounded to in-flight requests,
-  // same class as the existing voucher-store crash window. Per-chunk
-  // checkpointing would only SHRINK that hard-crash window (never close it —
-  // you can always crash between chunk and write) at a write-per-token cost, so
-  // we persist per terminal event instead.
-  // Terminal path: persist what we delivered. The lease is NOT touched here —
-  // its release is owned by the request lifecycle in tabMiddleware (res.on
-  // 'close'/'finish'), so a handler that never opens a meter still releases.
-  // Called on EVERY terminal path (clean end, cap-reject, disconnect), each
-  // guarded by `ended` so it fires exactly once.
-  async function persistDelivered(): Promise<void> {
-    await tab.recordDelivered(chargedAtomic.toString());
-  }
-
-  // Buyer-controlled termination: if the client drops the connection mid-stream
-  // the underlying response emits 'close'; commit what we delivered. Best-effort
-  // (can't await in an event handler), but the ledger write completes because on
-  // a disconnect the process is still alive. Guarded by `ended` so a normal
-  // end() — which also emits 'close' via res.end() — doesn't double-write.
-  res.on('close', () => {
+  // Delivery truth is write-ahead, not terminal best-effort. Every successful
+  // charge durably advances the fenced ledger BEFORE the caller may send its
+  // chunk. A hard crash can therefore conservatively account a chunk that was
+  // not sent; it can never send service that disappears from restart state.
+  // Close only marks the local meter terminal; there is nothing left to flush.
+  res.prependListener('close', () => {
     if (ended) return;
     ended = true;
-    void persistDelivered().catch((err) => {
-      // Best-effort: a failed disconnect-persist must not crash the process. The
-      // residual unpersisted window is the documented hard-crash case.
-      console.error('[tab/seller] terminal persist failed on disconnect:', err);
-    });
   });
 
-  async function charge(units = 1): Promise<void> {
-    if (ended) throw new Error('meter ended');
-    if (perUnitAtomic === null) throw new Error('charge() needs options.perUnit');
-    const inc = perUnitAtomic * BigInt(units);
-    const next = chargedAtomic + inc;
-    if (next > budgetAtomic) {
-      ended = true; // terminate: no further send()/charge() past the cap
-      await persistDelivered(); // commit what we DID deliver before refusing
-      throw new ScopeViolationError(
-        'cumulative_exceeds_cap',
-        `chunk would push delivered to ${atomicToHuman((deliveredBaselineAtomic + next).toString())} ` +
-        `beyond signed cumulative ${atomicToHuman(signedAtomic.toString())} ` +
-        `(per-request budget ${atomicToHuman(budgetAtomic.toString())})`,
-      );
+  function charge(units = 1): Promise<void> {
+    if (ended) return Promise.reject(new Error('meter ended'));
+    if (perUnitAtomic === null) {
+      return Promise.reject(new Error('charge() needs options.perUnit'));
     }
-    chargedAtomic = next;
+    if (!Number.isSafeInteger(units) || units <= 0) {
+      return Promise.reject(new Error('charge() units must be a positive safe integer'));
+    }
+    const inc = perUnitAtomic * BigInt(units);
+    pendingCharges += 1;
+    const run = chargeTail.then(async () => {
+      // Re-check inside the serialized section: another queued charge may have
+      // consumed the remaining signed budget while this call was waiting.
+      if (ended) throw new Error('meter ended');
+      const next = chargedAtomic + inc;
+      if (next > budgetAtomic) {
+        ended = true; // terminate: no further send()/charge() past the cap
+        throw new ScopeViolationError(
+          'cumulative_exceeds_cap',
+          `chunk would push delivered to ${atomicToHuman((deliveredBaselineAtomic + next).toString())} ` +
+          `beyond signed cumulative ${atomicToHuman(signedAtomic.toString())} ` +
+          `(per-request budget ${atomicToHuman(budgetAtomic.toString())})`,
+        );
+      }
+      try {
+        await tab.recordDelivered(inc.toString());
+        chargedAtomic = next;
+      } catch (error) {
+        // Store/lease ambiguity fails closed before caller-controlled send().
+        // If the write committed but its acknowledgement was lost, conservative
+        // over-accounting is safer than re-delivering the same signed budget.
+        ended = true;
+        throw error;
+      }
+    });
+    chargeTail = run.catch(() => undefined);
+    return run.finally(() => {
+      pendingCharges -= 1;
+    });
   }
 
   function send(chunk: string | Uint8Array): void {
     if (ended) throw new Error('meter ended');
+    if (pendingCharges > 0) {
+      throw new Error('charge still pending; await meter.charge() before send()');
+    }
     const data = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
     // Escape backslashes BEFORE newlines so the client's unescape is a true
     // inverse. The old newline-only escape corrupted payloads that already
@@ -146,7 +144,6 @@ export function openSse(res: Response, options: OpenSseOptions): SseMeter {
   async function end(): Promise<void> {
     if (ended) return;
     ended = true;
-    await persistDelivered();
     res.write(`event: end\ndata: {"chargedAtomic":"${chargedAtomic}"}\n\n`);
     res.end();
   }

--- a/src/tab/seller/middleware.ts
+++ b/src/tab/seller/middleware.ts
@@ -49,7 +49,15 @@ import {
   ScopeViolationError,
 } from './verify';
 
-import { InMemoryChannelLedger, withChannelLock, type ChannelLedger, type ChannelLedgerEntry } from './channel-ledger';
+import {
+  ChannelLeaseLostError,
+  InMemoryChannelLedger,
+  normalizeLeaseTtlMs,
+  type ChannelLedger,
+  type ChannelLedgerEntry,
+  type ChannelLedgerUpdater,
+  type ChannelLease,
+} from './channel-ledger';
 import { atomicToHuman, humanToAtomic, DEFAULT_FACILITATOR_URL } from '../tab';
 import { finalVoucherV2ReservationIdentity } from '../reservation';
 import {
@@ -78,6 +86,63 @@ export interface TabMiddlewareConfig extends TabMiddlewareOptions {
 
 /** Header the buyer sends with each paid request. Base64 JSON voucher envelope. */
 export const TAB_VOUCHER_HEADER = 'x-tab-voucher';
+
+class ResponseTerminatedError extends Error {
+  constructor() {
+    super('response terminated before tab admission completed');
+    this.name = 'ResponseTerminatedError';
+  }
+}
+
+function resolveLedgerSafetyMode(
+  configured: TabMiddlewareOptions['ledgerSafetyMode'],
+): NonNullable<TabMiddlewareOptions['ledgerSafetyMode']> {
+  if (configured !== undefined) return configured;
+  if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+    return 'development';
+  }
+  throw new Error(
+    'tab seller ledgerSafetyMode must be explicit outside NODE_ENV=test/development; ' +
+      'choose production-single-instance or production-multi-instance for deployment',
+  );
+}
+
+function assertLedgerSafety(
+  ledger: ChannelLedger,
+  mode: NonNullable<TabMiddlewareOptions['ledgerSafetyMode']>,
+): void {
+  if (![
+    'development',
+    'production-single-instance',
+    'production-multi-instance',
+  ].includes(mode)) {
+    throw new Error(`invalid tab seller ledgerSafetyMode: ${String(mode)}`);
+  }
+  const capabilities = ledger.capabilities;
+  if (!capabilities || capabilities.conditionalWrites !== true) {
+    throw new Error(
+      'tab seller ledger must declare conditional owner-token/fence writes',
+    );
+  }
+  if (mode !== 'development' && !capabilities.restartSafe) {
+    throw new Error(
+      `tab seller ${mode} requires restart-safe durable ledger state; ` +
+        `${capabilities.adapter} is not restart-safe`,
+    );
+  }
+  if (mode !== 'development' && !capabilities.canonicalChannelIds) {
+    throw new Error(
+      `tab seller ${mode} requires the legacy channel-id alias migration or an empty-store proof; ` +
+        `${capabilities.adapter} has no canonical channel-id cutover acknowledgement`,
+    );
+  }
+  if (mode === 'production-multi-instance' && !capabilities.multiInstanceSafe) {
+    throw new Error(
+      `tab seller production-multi-instance requires cross-process atomic fencing; ` +
+        `${capabilities.adapter} is single-instance only`,
+    );
+  }
+}
 
 // ── Session cache ──────────────────────────────────────────────────────
 //
@@ -217,10 +282,10 @@ function hexToBytes(hex: string): Uint8Array {
 // voucherPayloadMessage encodes it). We just hex-decode.
 
 function channelIdHexToBytes(hex: string): Uint8Array {
-  if (!/^[0-9a-f]{64}$/i.test(hex)) {
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
     throw new InvalidVoucherError(
       'signature_invalid',
-      `channelId must be 64-char hex, got "${hex}"`,
+      `channelId must be canonical lowercase 64-char hex, got "${hex}"`,
     );
   }
   return hexToBytes(hex);
@@ -230,6 +295,11 @@ function channelIdHexToBytes(hex: string): Uint8Array {
 
 export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
   const ledger: ChannelLedger = config.ledger ?? new InMemoryChannelLedger();
+  const ledgerSafetyMode = resolveLedgerSafetyMode(config.ledgerSafetyMode);
+  // Construction-time fail-closed gate. A production typo cannot silently
+  // turn durable seller revenue state into an in-memory ledger.
+  assertLedgerSafety(ledger, ledgerSafetyMode);
+  const leaseTtlMs = normalizeLeaseTtlMs(config.leaseTtlMs ?? 300_000);
   const cache = new SessionCache();
   const sellerPubkey =
     typeof config.sellerPubkey === 'string'
@@ -250,10 +320,60 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
   };
 
   return async (req: Request, res: Response, next: NextFunction) => {
-    let provisionalV2CacheEntry: {
+    let provisionalCacheEntry: {
       channelId: string;
       entry: SessionCacheEntry;
     } | null = null;
+    let heldLease: {
+      channelId: string;
+      lease: ChannelLease;
+      releaseStarted: boolean;
+    } | null = null;
+    let leaseHeartbeat: ReturnType<typeof setInterval> | null = null;
+    let leaseRenewal: Promise<void> | null = null;
+    let leaseFailure: Error | null = null;
+    let responseTerminated = false;
+    let assertLeaseActive = async (): Promise<void> => {
+      if (leaseFailure) throw leaseFailure;
+    };
+
+    const releaseHeldLease = async (): Promise<void> => {
+      if (!heldLease || heldLease.releaseStarted) return;
+      const held = heldLease;
+      held.releaseStarted = true;
+      if (leaseHeartbeat) {
+        clearInterval(leaseHeartbeat);
+        leaseHeartbeat = null;
+      }
+      if (leaseRenewal) {
+        await leaseRenewal.catch(() => undefined);
+      }
+      try {
+        await ledger.releaseLease(held.channelId, heldLease?.lease ?? held.lease);
+      } catch (error) {
+        // Allow the response error path to retry once. Store failures surface
+        // loudly; no in-memory release/fallback is attempted.
+        held.releaseStarted = false;
+        throw error;
+      }
+    };
+    const onResponseTerminated = () => {
+      if (responseTerminated) return;
+      responseTerminated = true;
+      setImmediate(() => {
+        void releaseHeldLease().catch((error) => {
+          console.error('[tab/seller] failed to release channel lease on response termination:', error);
+        });
+      });
+    };
+    const assertResponseOpen = () => {
+      if (responseTerminated) throw new ResponseTerminatedError();
+    };
+    // Register before any registration/RPC proof. A close event is one-shot;
+    // waiting until after proof can miss it and leave a later-acquired heartbeat
+    // renewing a dead request forever.
+    res.on('close', onResponseTerminated);
+    res.on('finish', onResponseTerminated);
     try {
       // 1. Decode the voucher off the header.
       const decoded = decodeVoucherHeader(req.headers[TAB_VOUCHER_HEADER]);
@@ -268,20 +388,19 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       // V2 refreshes it on every voucher together with currentOutstanding.
       let chainFrontierAtomic: string | null = null;
       let onChain: OnChainSessionFrontier | undefined;
-      let cacheEntryAfterV2Admission = false;
+      let cacheEntryAfterAdmission = false;
       if (!entry) {
         // First voucher for this channel. Historical V1 verifies the
-        // registration directly. V2 defers caching until its exact confirmed
-        // transaction + post-state proof and every local static scope check
-        // succeed, so a rejected request cannot poison the process cache for
-        // a legitimate channel.
+        // registration directly. Both generations defer caching until durable
+        // lease ownership, registration binding, and the accepted-voucher write
+        // succeed, so a rejected/losing request cannot poison this process for
+        // the channel's real owner.
+        cacheEntryAfterAdmission = true;
         const parsed = parseRegistration(voucher.sessionRegistration);
         if (nativeTabWireVersion(parsed.nonce) === 1) {
           onChain = await verifyRegistrationOnChain(config.connection, parsed);
           // Defensive `?.`: custom/mocked verifiers may still return void.
           chainFrontierAtomic = onChain?.frontierAtomic ?? null;
-        } else {
-          cacheEntryAfterV2Admission = true;
         }
         // Seed the monotonicity/increment baseline from the durable ledger's
         // last accepted voucher. Without this, a restarted process treats a
@@ -294,7 +413,6 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           registrationBytes: voucher.sessionRegistration.slice(),
           lastCumulativeAtomic: persisted?.lastVoucher?.payload.cumulativeAmount ?? '0',
         };
-        if (!cacheEntryAfterV2Admission) cache.set(channelId, entry);
       } else if (!sameBytes(entry.registrationBytes, voucher.sessionRegistration)) {
         // Cache hits must not turn the buyer-chosen channel id into an
         // authorization oracle. Without this exact binding, an attacker can
@@ -347,6 +465,8 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       const previous = BigInt(entry.lastCumulativeAtomic);
       let authorizationBaseline = previous;
       let reservationDelta: bigint | null = null;
+      let claimedReservation: bigint | null = null;
+      let verifiedCurrentOutstanding: bigint | null = null;
 
       if (registrationWireVersion === 2) {
         if (!reservationReceipt) {
@@ -355,7 +475,7 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
             'Native Tab V2 reservation proof was not carried through admission',
           );
         }
-        const claimedReservation = parseOnChainAtomic(
+        claimedReservation = parseOnChainAtomic(
           reservationReceipt.reservationAmountAtomic,
           'receipt.reservationAmountAtomic',
         );
@@ -442,6 +562,7 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           onChain.currentOutstandingAtomic,
           'currentOutstandingAtomic',
         );
+        verifiedCurrentOutstanding = currentOutstanding;
         if (currentOutstanding !== reservationDelta) {
           throw new InvalidVoucherError(
             'reservation_mismatch',
@@ -457,18 +578,25 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       }
 
       // 4. Enforce scope: cap, expiry, counterparty, monotonicity. V2 uses the
-      // authoritative covered baseline; V1 retains its cached seller baseline.
+      // authoritative covered baseline. Historical V1 may reconnect with a
+      // higher sequence at the same cumulative to consume previously
+      // under-delivered headroom; the exact durable sequence check happens
+      // after lease acquisition below.
+      const v1EqualCumulativeReconnect =
+        registrationWireVersion === 1 && cumulative === authorizationBaseline;
       enforceScope({
         registration: entry.registration,
         voucher,
         expectedCounterparty: sellerPubkey,
-        previousCumulativeAtomic: authorizationBaseline.toString(),
+        previousCumulativeAtomic: v1EqualCumulativeReconnect
+          ? undefined
+          : authorizationBaseline.toString(),
       });
 
       // 5. Bound per-voucher increment. Protects against a giant single
       //    voucher slipping through; the buyer's perUnitCap should prevent
       //    this from the client side but the seller still defends.
-      const increment = cumulative - authorizationBaseline;
+      let increment = cumulative - authorizationBaseline;
       if (increment > maxPerVoucherAtomic) {
         throw new ScopeViolationError(
           'cumulative_exceeds_cap',
@@ -479,7 +607,7 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       // Re-read after all RPC awaits. A concurrently admitted winner may now
       // exist even though the cache was empty when this request began. Do not
       // bind a new entry yet: the durable lease must be acquired first.
-      if (cacheEntryAfterV2Admission) {
+      if (cacheEntryAfterAdmission) {
         const winner = cache.get(channelId);
         if (winner) {
           if (!sameBytes(winner.registrationBytes, entry.registrationBytes)) {
@@ -505,24 +633,160 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
 
       // 5b. One live stream per channel: acquire the lease or reject. Closes the
       //     concurrent-same-channel over-delivery rug.
-      const leaseTtlMs = config.leaseTtlMs ?? 300_000;
-      if (!(await ledger.tryAcquireLease(channelId, leaseTtlMs))) {
+      assertResponseOpen();
+      const lease = await ledger.tryAcquireLease(channelId, leaseTtlMs);
+      if (!lease) {
         throw new InvalidVoucherError(
           'channel_busy',
           'another stream is live on this channel; tabs serve one stream at a time',
         );
       }
+      heldLease = { channelId, lease, releaseStarted: false };
+      assertResponseOpen();
+
+      // A live stream may legitimately outlast one TTL. Renew the exact owner
+      // token + fence every third of the lease window. A renewal/store failure
+      // permanently fails this request closed and destroys the response; every
+      // charged chunk is already write-ahead persisted before delivery.
+      const heartbeatMs = Math.max(1, Math.floor(leaseTtlMs / 3));
+      const renewHeldLease = async (): Promise<void> => {
+        if (leaseFailure) throw leaseFailure;
+        if (!heldLease || heldLease.releaseStarted) {
+          throw new ChannelLeaseLostError(channelId);
+        }
+        if (leaseRenewal) return leaseRenewal;
+        leaseRenewal = (async () => {
+          const renewed = await ledger.renewLease(
+            channelId,
+            heldLease!.lease,
+            leaseTtlMs,
+          );
+          if (heldLease && !heldLease.releaseStarted) heldLease.lease = renewed;
+        })()
+          .catch((error: unknown) => {
+            const failure = error instanceof Error ? error : new Error(String(error));
+            leaseFailure = failure;
+            console.error(
+              `[tab/seller] channel lease renewal FAILED channel=${channelId.slice(0, 16)}…; ` +
+                'stream terminated before further delivery:',
+              failure,
+            );
+            if (typeof (res as any).destroy === 'function') {
+              (res as any).destroy(failure);
+            }
+            throw failure;
+          })
+          .finally(() => {
+            leaseRenewal = null;
+          });
+        return leaseRenewal;
+      };
+      assertLeaseActive = async (): Promise<void> => {
+        if (leaseFailure) throw leaseFailure;
+        if (!heldLease || heldLease.releaseStarted) {
+          throw new ChannelLeaseLostError(channelId);
+        }
+        if (heldLease.lease.heldUntilUnixMs - Date.now() <= heartbeatMs) {
+          await renewHeldLease();
+        }
+      };
+      leaseHeartbeat = setInterval(() => {
+        void renewHeldLease().catch(() => {
+          // renewHeldLease records/logs the terminal failure exactly once.
+        });
+      }, heartbeatMs);
+      (leaseHeartbeat as any).unref?.();
+
+      // The pre-proof snapshot can be stale: another seller process may have
+      // admitted and released this channel while our RPC proof was in flight.
+      // Ownership is now exclusive, so bind the exact durable registration and
+      // repeat every baseline-dependent check before any cache/ledger mutation.
+      const postLeasePrior = await ledger.get(channelId);
+      assertResponseOpen();
+      if (
+        postLeasePrior?.lastVoucher
+        && !sameBytes(
+          postLeasePrior.lastVoucher.sessionRegistration,
+          voucher.sessionRegistration,
+        )
+      ) {
+        throw new InvalidVoucherSignatureError(
+          'durable channel registration changed while reservation proof was in flight',
+        );
+      }
+      const durableCumulative = BigInt(
+        postLeasePrior?.lastVoucher?.payload.cumulativeAmount ?? '0',
+      );
+      let postLeaseBaseline = BigInt(entry.lastCumulativeAtomic);
+      if (durableCumulative > postLeaseBaseline) postLeaseBaseline = durableCumulative;
+      if (registrationWireVersion === 2 && chainFrontierAtomic !== null) {
+        const chainFrontier = parseOnChainAtomic(chainFrontierAtomic, 'frontierAtomic');
+        if (chainFrontier > postLeaseBaseline) postLeaseBaseline = chainFrontier;
+      }
+      const v1EqualPostLeaseReconnect =
+        registrationWireVersion === 1 && cumulative === postLeaseBaseline;
+      if (
+        cumulative < postLeaseBaseline
+        || (registrationWireVersion === 2 && cumulative === postLeaseBaseline)
+      ) {
+        throw new InvalidVoucherError(
+          registrationWireVersion === 2 ? 'voucher_already_covered' : 'non_monotonic',
+          `cumulative ${cumulative} is not above post-lease covered frontier ${postLeaseBaseline}`,
+        );
+      }
+      if (v1EqualPostLeaseReconnect) {
+        const durableVoucher = postLeasePrior?.lastVoucher;
+        if (
+          !durableVoucher
+          || BigInt(durableVoucher.payload.cumulativeAmount) !== cumulative
+          || voucher.payload.sequenceNumber <= durableVoucher.payload.sequenceNumber
+        ) {
+          throw new InvalidVoucherError(
+            'non_monotonic',
+            'same-cumulative V1 reconnect requires a strictly newer sequence than the durable voucher',
+          );
+        }
+      }
+      enforceScope({
+        registration: entry.registration,
+        voucher,
+        expectedCounterparty: sellerPubkey,
+        previousCumulativeAtomic: v1EqualPostLeaseReconnect
+          ? undefined
+          : postLeaseBaseline.toString(),
+      });
+      increment = cumulative - postLeaseBaseline;
+      if (increment > maxPerVoucherAtomic) {
+        throw new ScopeViolationError(
+          'cumulative_exceeds_cap',
+          `post-lease voucher increment ${increment} exceeds maxPerVoucherAtomic ${maxPerVoucherAtomic}`,
+        );
+      }
+      if (registrationWireVersion === 2) {
+        if (
+          claimedReservation === null
+          || verifiedCurrentOutstanding === null
+          || claimedReservation !== increment
+          || verifiedCurrentOutstanding !== increment
+        ) {
+          throw new InvalidVoucherError(
+            'reservation_mismatch',
+            'durable channel frontier advanced while reservation proof was in flight',
+          );
+        }
+      }
+      authorizationBaseline = postLeaseBaseline;
 
       // The durable lease serializes first-seen channel binding across all
       // requests sharing this ledger. Re-read once more after acquiring it,
       // then install only an exact provisional entry. If later durable ledger
       // I/O fails, the outer catch removes this exact object so a failed
       // admission cannot poison the process cache.
-      if (cacheEntryAfterV2Admission) {
+      if (cacheEntryAfterAdmission) {
         const winner = cache.get(channelId);
         if (winner) {
           if (!sameBytes(winner.registrationBytes, entry.registrationBytes)) {
-            await ledger.releaseLease(channelId);
+            await releaseHeldLease();
             throw new InvalidVoucherSignatureError(
               'voucher registration lost the channel lease race to a different verified registration',
             );
@@ -530,24 +794,32 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           entry = winner;
         } else {
           cache.set(channelId, entry);
-          provisionalV2CacheEntry = { channelId, entry };
+          provisionalCacheEntry = { channelId, entry };
         }
       }
 
-      // Release the lease when the response completes for ANY reason (stream end,
-      // non-streaming response, handler error, client disconnect). Owned by the
-      // request lifecycle, not the meter — a handler that never opens a meter
-      // must not leak the lease for the whole TTL.
-      let leaseReleased = false;
-      const releaseOnce = () => {
-        if (leaseReleased) return;
-        leaseReleased = true;
-        void ledger.releaseLease(channelId).catch((err) => {
-          console.error('[tab/seller] failed to release channel lease:', err);
-        });
+      const persistBackgroundMutation = async (
+        updater: ChannelLedgerUpdater,
+      ): Promise<ChannelLedgerEntry> => {
+        try {
+          return await ledger.update(channelId, lease, updater);
+        } catch (error) {
+          if (!(error instanceof ChannelLeaseLostError)) throw error;
+          // Detached crystallization can finish after the response releases its
+          // stream lease. Reacquire a short fenced lease only if the channel is
+          // idle; never write through another request's ownership.
+          const maintenanceLease = await ledger.tryAcquireLease(
+            channelId,
+            Math.min(leaseTtlMs, 15_000),
+          );
+          if (!maintenanceLease) throw error;
+          try {
+            return await ledger.update(channelId, maintenanceLease, updater);
+          } finally {
+            await ledger.releaseLease(channelId, maintenanceLease);
+          }
+        }
       };
-      res.on('close', releaseOnce);
-      res.on('finish', releaseOnce);
 
       // Keyless crystallization (Step-4 lock-mode). Threshold-driven cadence,
       // invoked from the recordDelivered closure; persists any advance to the
@@ -564,15 +836,34 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           // refused it below-cadence (gate-refused watermark advanced, §5
           // A12) — persist BOTH under the lock so the next request reads
           // them and doesn't re-fire on the same span.
-          await withChannelLock(channelId, async () => {
-            const cur = await ledger.get(channelId);
-            if (cur) {
-              await ledger.set(channelId, {
-                ...cur,
-                lastCrystallizedCumulativeAtomic: entry.lastCrystallizedCumulativeAtomic,
-                gateRefusedCumulativeAtomic: entry.gateRefusedCumulativeAtomic,
-              });
-            }
+          await persistBackgroundMutation((cur) => {
+            if (!cur) throw new Error('channel ledger entry missing during crystallize persist');
+            const crystallized = (
+              BigInt(cur.lastCrystallizedCumulativeAtomic ?? '0')
+              >= BigInt(entry.lastCrystallizedCumulativeAtomic ?? '0')
+            )
+              ? cur.lastCrystallizedCumulativeAtomic ?? '0'
+              : entry.lastCrystallizedCumulativeAtomic ?? '0';
+            const refusalCandidates = [
+              cur.gateRefusedCumulativeAtomic,
+              entry.gateRefusedCumulativeAtomic,
+            ].filter((value): value is string => value !== undefined);
+            const refused = refusalCandidates.reduce<string | undefined>(
+              (highest, value) => (
+                highest === undefined || BigInt(value) > BigInt(highest)
+                  ? value
+                  : highest
+              ),
+              undefined,
+            );
+            return {
+              ...cur,
+              lastCrystallizedCumulativeAtomic: crystallized,
+              gateRefusedCumulativeAtomic:
+                refused !== undefined && BigInt(refused) > BigInt(crystallized)
+                  ? refused
+                  : undefined,
+            };
           }).catch((err) => {
             // LOUD (no-silent-fallbacks): the outcome watermark didn't
             // persist — the next request will re-attempt the same span and
@@ -586,18 +877,30 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
         }
       };
 
+      // Threshold and close crystallization are detached from delivery, but
+      // they must observe one another's durable watermarks. Serialize this
+      // request's jobs and make each job re-read the ledger after the previous
+      // one persists; otherwise two rapid charges can both POST the same span
+      // before the first below-cadence refusal is visible.
+      let crystallizeTail: Promise<void> = Promise.resolve();
+      const queueCrystallize = (work: () => Promise<void>): Promise<void> => {
+        const run = crystallizeTail.then(work, work);
+        crystallizeTail = run.catch(() => undefined);
+        return run;
+      };
+
       // At close: crystallize the channel's FINAL signed voucher exactly once if
       // the cadence wants it. We read `lastVoucher` from the ledger at close —
       // NOT a `delivered` snapshot — which sidesteps the close-handler ordering
       // problem entirely: `lastVoucher` is persisted during the request (step 6,
       // before next()), so it is already the final signed voucher at close
-      // regardless of when the meter's own `persistDelivered` close handler
-      // writes `delivered`. We crystallize that voucher and advance the watermark
-      // to ITS cumulative (FIX C1/C2), so the watermark is truthful and never
-      // lies about a delivered span the lock didn't actually secure.
+      // while every delivered chunk was already written ahead before send. We
+      // crystallize that voucher and advance the watermark to ITS cumulative
+      // (FIX C1/C2), so the watermark is truthful and never lies about a
+      // delivered span the lock didn't actually secure.
       //
       // Fully best-effort: detached + swallows all errors. The `closeCrystallized`
-      // flag is INDEPENDENT of `leaseReleased` — they guard different concerns and
+      // flag is INDEPENDENT of `releaseOnce` — they guard different concerns and
       // must not be merged. Both handlers are registered on the same events; the
       // bodies are detached and run concurrently, so the lease release
       // (`releaseOnce`, registered earlier) is not gated on this crystallize.
@@ -605,7 +908,7 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       const crystallizeOnClose = () => {
         if (!lockCadence.onClose || closeCrystallized) return;
         closeCrystallized = true;
-        void (async () => {
+        void queueCrystallize(async () => {
           const cur = await ledger.get(channelId);
           if (!cur || !cur.lastVoucher) return;
           // The cumulative we will lock is the FINAL signed voucher's — captured
@@ -623,32 +926,43 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           }
           const result = await crystallizeNow(cur, channelId, facilitatorUrl, config.network);
           if (result.crystallized) {
-            await withChannelLock(channelId, async () => {
-              const latest = await ledger.get(channelId);
-              if (latest) {
-                await ledger.set(channelId, {
-                  ...latest,
-                  lastCrystallizedCumulativeAtomic: lockedCumulative,
-                  // A landed lock supersedes any stale refusal record.
-                  gateRefusedCumulativeAtomic: undefined,
-                });
-              }
+            await persistBackgroundMutation((latest) => {
+              if (!latest) throw new Error('channel ledger entry missing during close crystallize');
+              const crystallized = BigInt(latest.lastCrystallizedCumulativeAtomic ?? '0')
+                >= BigInt(lockedCumulative)
+                ? latest.lastCrystallizedCumulativeAtomic ?? '0'
+                : lockedCumulative;
+              return {
+                ...latest,
+                lastCrystallizedCumulativeAtomic: crystallized,
+                // A landed lock supersedes refusal state only through the
+                // amount it actually secured; never erase a newer watermark.
+                gateRefusedCumulativeAtomic:
+                  latest.gateRefusedCumulativeAtomic !== undefined
+                  && BigInt(latest.gateRefusedCumulativeAtomic) > BigInt(crystallized)
+                    ? latest.gateRefusedCumulativeAtomic
+                    : undefined,
+              };
             });
           } else if (isGateRefused(result.error)) {
             // Record the below-cadence refusal so later closes/deliveries of
             // the SAME span stay quiet (§5 A12). Benign — logged once by
             // crystallizeNow's outcome table.
-            await withChannelLock(channelId, async () => {
-              const latest = await ledger.get(channelId);
-              if (latest) {
-                await ledger.set(channelId, {
-                  ...latest,
-                  gateRefusedCumulativeAtomic: lockedCumulative,
-                });
-              }
+            await persistBackgroundMutation((latest) => {
+              if (!latest) throw new Error('channel ledger entry missing during close refusal persist');
+              const crystallized = BigInt(latest.lastCrystallizedCumulativeAtomic ?? '0');
+              const refused = latest.gateRefusedCumulativeAtomic !== undefined
+                && BigInt(latest.gateRefusedCumulativeAtomic) >= BigInt(lockedCumulative)
+                ? latest.gateRefusedCumulativeAtomic
+                : lockedCumulative;
+              return {
+                ...latest,
+                gateRefusedCumulativeAtomic:
+                  BigInt(refused) > crystallized ? refused : undefined,
+              };
             });
           }
-        })().catch((err) => {
+        }).catch((err) => {
           // LOUD (no-silent-fallbacks): the close-path crystallize is the last
           // chance to secure this request's final voucher — a crash here means
           // the seller's exposure stays unsecured with no on-chain claim.
@@ -663,15 +977,13 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       res.on('finish', crystallizeOnClose);
 
       // 6. Read the durable delivered baseline for the budget, then persist the
-      //    accepted voucher WITHOUT touching delivered (delivered only advances
-      //    on the meter's terminal path). Locked so a concurrent request can't
-      //    interleave a stale write. Spread `...cur` so we PRESERVE the lease (and
-      //    onChain) we just acquired — omitting it would erase the lease one line
-      //    after acquiring it, reopening the concurrent-same-channel rug.
-      const prior = await ledger.get(channelId);
-      // A ledger entry is FRESH when it has never seen a voucher or delivery —
-      // tryAcquireLease auto-creates zeroed entries, so `prior != null` alone
-      // does not mean history exists. V1 retains the historical fresh-only
+      //    accepted voucher WITHOUT touching delivered (each later meter charge
+      //    advances delivered before its chunk is sent). Locked so a concurrent
+      //    request can't interleave a stale write. The adapter keeps lease
+      //    identity separate and conditionally commits on owner token + fence.
+      const prior = postLeasePrior;
+      // A ledger entry is FRESH when it has never seen a voucher or delivery.
+      // V1 retains the historical fresh-only
       // seed. V2 advances even an existing ledger's delivery floor when the
       // authoritative chain frontier has moved, preventing another process's
       // already-settled delivery from becoming fresh budget here.
@@ -698,10 +1010,8 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           : prior
             ? BigInt(prior.deliveredCumulativeAtomic)
             : 0n;
-      await withChannelLock(channelId, async () => {
-        const cur = await ledger.get(channelId);
-        await ledger.set(channelId, {
-          ...cur,
+      await ledger.update(channelId, lease, (cur) => ({
+          ...(cur ?? {}),
           lastVoucher: voucher,
           deliveredCumulativeAtomic:
             seedAtomic ?? (cur ? cur.deliveredCumulativeAtomic : '0'),
@@ -710,9 +1020,9 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
           // starts at zero on a resume.
           lastCrystallizedCumulativeAtomic:
             seedAtomic ?? cur?.lastCrystallizedCumulativeAtomic ?? '0',
-        });
-      });
-      provisionalV2CacheEntry = null;
+        }));
+      provisionalCacheEntry = null;
+      assertResponseOpen();
 
       // 7. Update the hot-path registration cache and attach the SellerTab.
       cache.update(channelId, voucher.payload.cumulativeAmount);
@@ -721,35 +1031,48 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
         config.network,
         cumulative,
         deliveredBaselineAtomic,
-        // recordDelivered: the meter calls this on terminal events to persist
-        // the new lifetime delivered cumulative. Spread `...cur` to PRESERVE the
-        // lease (held by the request lifecycle until the response closes) and
-        // onChain — omitting them would erase the lease mid-stream.
+        // recordDelivered: the meter calls this for each write-ahead chunk
+        // before service using this request's exact owner token + fence. A
+        // post-takeover writer fails closed.
         async (incrementAtomic: string) => {
+          await assertLeaseActive();
           let updated: ChannelLedgerEntry | null = null;
-          await withChannelLock(channelId, async () => {
-            const cur = await ledger.get(channelId);
-            const base = cur ? BigInt(cur.deliveredCumulativeAtomic) : 0n;
+          updated = await ledger.update(channelId, lease, (cur) => {
+            if (!cur?.lastVoucher || !sameVoucherIdentity(cur.lastVoucher, voucher)) {
+              throw new InvalidVoucherSignatureError(
+                'durable voucher identity changed before delivery accounting',
+              );
+            }
+            const base = BigInt(cur.deliveredCumulativeAtomic);
             const inc = BigInt(incrementAtomic);
             const nextDelivered = inc > 0n ? base + inc : base; // monotonic, never backward
+            const signedCumulative = BigInt(cur.lastVoucher.payload.cumulativeAmount);
+            if (nextDelivered > signedCumulative) {
+              throw new ScopeViolationError(
+                'cumulative_exceeds_cap',
+                `durable delivered cumulative ${nextDelivered} exceeds signed cumulative ${signedCumulative}`,
+              );
+            }
             const next: ChannelLedgerEntry = {
               ...cur,
-              lastVoucher: cur?.lastVoucher ?? voucher,
+              lastVoucher: cur.lastVoucher,
               deliveredCumulativeAtomic: nextDelivered.toString(),
               lastCrystallizedCumulativeAtomic:
-                cur?.lastCrystallizedCumulativeAtomic ?? '0',
+                cur.lastCrystallizedCumulativeAtomic ?? '0',
             };
-            await ledger.set(channelId, next);
-            updated = next;
+            return next;
           });
           // Keyless crystallization cadence (Step-4). BEST-EFFORT: fire OUTSIDE
           // the channel lock so the network POST never serializes delivered
           // writes, and detach it so a slow/failed lock never blocks or rejects
-          // the meter's terminal path. maybeCrystallize advances
+          // the already-durable delivery charge. maybeCrystallize advances
           // `lastCrystallizedCumulativeAtomic` in memory on success; persist
           // that advance back so the next request doesn't re-fire.
           if (updated) {
-            void crystallizeCadence(updated).catch((err) => {
+            void queueCrystallize(async () => {
+              const latest = await ledger.get(channelId);
+              if (latest) await crystallizeCadence(latest);
+            }).catch((err) => {
               // LOUD (no-silent-fallbacks): the threshold cadence crashed
               // before it could even attempt the lock POST.
               console.error(
@@ -773,12 +1096,18 @@ export function tabMiddleware(config: TabMiddlewareConfig): RequestHandler {
       req.tab = tab;
       next();
     } catch (err) {
-      if (provisionalV2CacheEntry) {
+      if (heldLease && !heldLease.releaseStarted) {
+        await releaseHeldLease().catch((releaseError) => {
+          console.error('[tab/seller] failed to release channel lease after request error:', releaseError);
+        });
+      }
+      if (provisionalCacheEntry) {
         cache.deleteIfSame(
-          provisionalV2CacheEntry.channelId,
-          provisionalV2CacheEntry.entry,
+          provisionalCacheEntry.channelId,
+          provisionalCacheEntry.entry,
         );
       }
+      if (err instanceof ResponseTerminatedError) return;
       // Map our internal errors to 402 with a structured body.
       if (
         err instanceof InvalidVoucherError ||
@@ -806,6 +1135,15 @@ function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
     difference |= left[index] ^ right[index];
   }
   return difference === 0;
+}
+
+function sameVoucherIdentity(left: SignedVoucher, right: SignedVoucher): boolean {
+  return left.payload.channelId === right.payload.channelId
+    && left.payload.cumulativeAmount === right.payload.cumulativeAmount
+    && left.payload.sequenceNumber === right.payload.sequenceNumber
+    && sameBytes(left.sessionPublicKey, right.sessionPublicKey)
+    && sameBytes(left.sessionRegistration, right.sessionRegistration)
+    && sameBytes(left.sessionSignature, right.sessionSignature);
 }
 
 function parseOnChainAtomic(value: string, field: string): bigint {

--- a/src/tab/seller/redis-channel-ledger.ts
+++ b/src/tab/seller/redis-channel-ledger.ts
@@ -1,6 +1,6 @@
 /**
  * Redis-backed ChannelLedger — the multi-process production ledger the
- * ChannelLedger interface docs call for ("Redis SETNX"): revenue state
+ * ChannelLedger interface docs call for: revenue state
  * survives restarts, and the single-stream lease is atomic ACROSS processes.
  *
  * Zero new dependencies: the constructor takes a structural `RedisLikeClient`
@@ -11,28 +11,47 @@
  *      (`enableOfflineQueue: false` on ioredis). A Redis outage must surface
  *      as a thrown ledger error the seller can terminate a stream on — never
  *      an indefinite hang inside the payment path.
- *   2. NO EVICTION on the keyspace holding these entries
- *      (`maxmemory-policy noeviction`, or a dedicated logical DB). Ledger
- *      entries are revenue state; an evicted entry silently re-grants
- *      delivered budget.
+ *   2. DURABLE, NO-ROLLBACK persistence/failover plus server-wide NO EVICTION.
+ *      A logical DB does not isolate Redis's server-wide eviction policy. To
+ *      declare `restartSafe`, pass the explicit durability attestation AND
+ *      writer-generation cutover acknowledgement to the constructor only
+ *      after verifying AOF always, no-loss failover,
+ *      `maxmemory-policy noeviction`, a dedicated Redis instance, and that
+ *      every pre-fencing SDK writer has stopped.
  *
- * Key layout (prefix configurable):
- *   <prefix>ledger:<channelId>  — serialized entry, NO TTL (durable until the
- *                                 seller's end-of-life sweep deletes it)
- *   <prefix>lease:<channelId>   — single-stream lease, PX = leaseTtlMs,
- *                                 value = per-acquire random token
+ * Key layouts (prefix configurable):
+ *   legacy-v0 (default, upgrade-compatible with <= 6.0.0-rc.2):
+ *     <prefix>ledger:<channelId> / lease:<channelId> / fence:<channelId>
+ *   cluster-v1 (explicit stop-the-world migration):
+ *     <prefix>{<channelId>}:ledger / :lease / :fence
+ * The cluster-v1 hash tag keeps each channel's Lua keys in one Redis Cluster
+ * slot. It is never selected implicitly: hiding legacy delivery state or using
+ * a different lease key during a rolling deploy would re-grant buyer budget.
  *
- * Lease semantics: acquire is SET NX PX (atomic across processes); release is
- * a compare-and-delete Lua script on the acquire token, so an instance that
- * lost its lease to TTL expiry can never delete the next holder's lease.
+ * Lease semantics: acquire atomically checks the lease, INCRs the fence, and
+ * installs owner:fence with PX. Every entry write/delete and lease release is
+ * a Lua compare-and-mutate on that exact owner:fence identity. An expired or
+ * crashed process therefore cannot overwrite or release a takeover owner's
+ * state when it resumes.
  */
 
 import { randomUUID } from 'node:crypto';
 
-import type { ChannelLedger, ChannelLedgerEntry } from './channel-ledger';
+import type {
+  ChannelLedger,
+  ChannelLedgerCapabilities,
+  ChannelLedgerEntry,
+  ChannelLedgerUpdater,
+  ChannelLease,
+  ChannelIdCutover,
+} from './channel-ledger';
 import {
+  ChannelLeaseLostError,
   serializeChannelLedgerEntry,
   deserializeChannelLedgerEntry,
+  assertCanonicalChannelId,
+  normalizeLeaseTtlMs,
+  withChannelLock,
   type SerializedEntry,
 } from './channel-ledger';
 
@@ -44,61 +63,341 @@ export interface RedisLikeClient {
   eval(script: string, numKeys: number, ...args: Array<string | number>): Promise<unknown>;
 }
 
-const RELEASE_IF_TOKEN_MATCHES_LUA =
-  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
+/**
+ * Explicit operator attestation required before this adapter may advertise
+ * restart safety. These are deployment facts a structural Redis client cannot
+ * infer. Omitting this keeps `restartSafe=false`, so production safety modes
+ * fail closed instead of trusting a lossy/default Redis server.
+ */
+export interface RedisDurabilityAttestation {
+  persistence: 'aof-always';
+  failover: 'no-data-loss';
+  maxmemoryPolicy: 'noeviction';
+  isolation: 'dedicated-instance';
+}
+
+export type RedisKeyLayout = 'legacy-v0' | 'cluster-v1';
+
+export interface RedisChannelLedgerOptions {
+  keyPrefix?: string;
+  durability?: RedisDurabilityAttestation;
+  /**
+   * Explicit writer-generation fence. Production restart safety is advertised
+   * only after every pre-fencing SDK process has been stopped; those versions
+   * could write the legacy ledger without an owner/fence condition.
+   */
+  writerCutover?: 'all-legacy-writers-stopped';
+  /** Required in production after merging/removing historical case aliases. */
+  channelIdCutover?: ChannelIdCutover;
+  /** Default `legacy-v0`, preserving the <= 6.0.0-rc.2 Redis keyspace. */
+  keyLayout?: RedisKeyLayout;
+  /** Required for cluster-v1 after legacy state has been migrated or proven empty. */
+  keyspaceCutover?: 'legacy-state-migrated-or-empty';
+}
+
+function isDurabilityAttestation(value: unknown): value is RedisDurabilityAttestation {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return candidate.persistence === 'aof-always'
+    && candidate.failover === 'no-data-loss'
+    && candidate.maxmemoryPolicy === 'noeviction'
+    && candidate.isolation === 'dedicated-instance';
+}
+
+const ACQUIRE_FENCED_LEASE_LUA = `
+if redis.call("exists", KEYS[1]) == 1 then return false end
+redis.call("incr", KEYS[2])
+local fence = redis.call("get", KEYS[2])
+redis.call("set", KEYS[1], ARGV[1] .. ":" .. tostring(fence), "PX", ARGV[2])
+return tostring(fence)
+`;
+
+const SET_IF_LEASE_MATCHES_LUA = `
+if redis.call("get", KEYS[1]) ~= ARGV[1] then return 0 end
+redis.call("set", KEYS[2], ARGV[2])
+return 1
+`;
+
+const DELETE_IF_LEASE_MATCHES_LUA = `
+if redis.call("get", KEYS[1]) ~= ARGV[1] then return 0 end
+redis.call("del", KEYS[2])
+return 1
+`;
+
+const RELEASE_IF_LEASE_MATCHES_LUA = `
+if redis.call("get", KEYS[1]) ~= ARGV[1] then return 0 end
+return redis.call("del", KEYS[1])
+`;
+
+const RENEW_IF_LEASE_MATCHES_LUA = `
+if redis.call("get", KEYS[1]) ~= ARGV[1] then return 0 end
+redis.call("pexpire", KEYS[1], ARGV[2])
+return 1
+`;
+
+// EVAL is routed to the key's primary even when an ioredis Cluster client is
+// configured to scale ordinary GETs to replicas. Seller delivery truth may
+// never be derived from a lagging replica.
+const READ_FROM_PRIMARY_LUA = 'return redis.call("get", KEYS[1])';
+
+export class RedisKeyspaceMigrationRequiredError extends Error {
+  constructor(channelId: string) {
+    super(
+      `legacy Redis seller state exists for channel ${channelId}; stop all legacy writers, ` +
+        'migrate/delete the legacy ledger, lease, and fence keys, then retry cluster-v1',
+    );
+    this.name = 'RedisKeyspaceMigrationRequiredError';
+  }
+}
+
+function leaseIdentity(lease: ChannelLease): string {
+  return `${lease.ownerToken}:${lease.fence}`;
+}
+
+function mutationSucceeded(result: unknown): boolean {
+  return result === 1 || result === '1';
+}
 
 export class RedisChannelLedger implements ChannelLedger {
-  /** Tokens for leases THIS instance holds; release only compares-and-deletes its own. */
-  private readonly leaseTokens = new Map<string, string>();
+  readonly capabilities: ChannelLedgerCapabilities;
+  private readonly keyPrefix: string;
+  private readonly keyLayout: RedisKeyLayout;
 
   constructor(
     private readonly client: RedisLikeClient,
-    private readonly keyPrefix: string = 'tab:',
-  ) {}
+    keyPrefixOrOptions: string | RedisChannelLedgerOptions = 'tab:',
+  ) {
+    if (
+      typeof keyPrefixOrOptions !== 'string'
+      && (
+        keyPrefixOrOptions === null
+        || typeof keyPrefixOrOptions !== 'object'
+        || Array.isArray(keyPrefixOrOptions)
+      )
+    ) {
+      throw new Error('RedisChannelLedger options must be a key prefix or options object');
+    }
+    const options: RedisChannelLedgerOptions = typeof keyPrefixOrOptions === 'string'
+      ? { keyPrefix: keyPrefixOrOptions }
+      : keyPrefixOrOptions;
+    if (options.keyPrefix !== undefined && typeof options.keyPrefix !== 'string') {
+      throw new Error('RedisChannelLedger keyPrefix must be a string');
+    }
+    this.keyPrefix = options.keyPrefix ?? 'tab:';
+    this.keyLayout = options.keyLayout ?? 'legacy-v0';
+    if (!['legacy-v0', 'cluster-v1'].includes(this.keyLayout)) {
+      throw new Error(`invalid RedisChannelLedger keyLayout: ${String(this.keyLayout)}`);
+    }
+    if (
+      this.keyLayout === 'cluster-v1'
+      && (this.keyPrefix.includes('{') || this.keyPrefix.includes('}'))
+    ) {
+      throw new Error('cluster-v1 keyPrefix must not contain Redis hash-tag braces');
+    }
+    if (
+      options.writerCutover !== undefined
+      && options.writerCutover !== 'all-legacy-writers-stopped'
+    ) {
+      throw new Error('invalid RedisChannelLedger writerCutover acknowledgement');
+    }
+    if (
+      options.channelIdCutover !== undefined
+      && options.channelIdCutover !== 'legacy-case-aliases-migrated-or-empty'
+    ) {
+      throw new Error('invalid RedisChannelLedger channelIdCutover acknowledgement');
+    }
+    if (
+      this.keyLayout === 'cluster-v1'
+      && options.keyspaceCutover !== 'legacy-state-migrated-or-empty'
+    ) {
+      throw new Error(
+        'cluster-v1 requires keyspaceCutover: legacy-state-migrated-or-empty',
+      );
+    }
+    const durability = options.durability;
+    if (durability !== undefined && !isDurabilityAttestation(durability)) {
+      throw new Error(
+        'RedisChannelLedger durability attestation must confirm aof-always, ' +
+          'no-data-loss failover, noeviction, and dedicated-instance isolation',
+      );
+    }
+    this.capabilities = {
+      adapter: 'redis',
+      restartSafe:
+        isDurabilityAttestation(durability)
+        && options.writerCutover === 'all-legacy-writers-stopped',
+      multiInstanceSafe: true,
+      conditionalWrites: true,
+      canonicalChannelIds:
+        options.channelIdCutover === 'legacy-case-aliases-migrated-or-empty',
+    };
+  }
+
+  private assertChannelId(channelId: string): void {
+    assertCanonicalChannelId(channelId);
+  }
+
+  private legacyKey(channelId: string, suffix: 'ledger' | 'lease' | 'fence'): string {
+    this.assertChannelId(channelId);
+    return `${this.keyPrefix}${suffix}:${channelId}`;
+  }
+
+  private channelKey(channelId: string, suffix: 'ledger' | 'lease' | 'fence'): string {
+    this.assertChannelId(channelId);
+    return this.keyLayout === 'cluster-v1'
+      ? `${this.keyPrefix}{${channelId}}:${suffix}`
+      : this.legacyKey(channelId, suffix);
+  }
 
   private ledgerKey(channelId: string): string {
-    return `${this.keyPrefix}ledger:${channelId}`;
+    return this.channelKey(channelId, 'ledger');
   }
 
   private leaseKey(channelId: string): string {
-    return `${this.keyPrefix}lease:${channelId}`;
+    return this.channelKey(channelId, 'lease');
+  }
+
+  private fenceKey(channelId: string): string {
+    return this.channelKey(channelId, 'fence');
+  }
+
+  private async primaryGet(key: string): Promise<string | null> {
+    const raw = await this.client.eval(READ_FROM_PRIMARY_LUA, 1, key);
+    if (raw === null || raw === false) return null;
+    if (typeof raw !== 'string') {
+      throw new Error(`Redis primary GET returned invalid value type: ${typeof raw}`);
+    }
+    return raw;
+  }
+
+  private async assertClusterCutover(channelId: string): Promise<void> {
+    if (this.keyLayout !== 'cluster-v1') return;
+    // Read legacy keys separately so this check itself is valid on a Cluster.
+    // The constructor acknowledgement requires old writers to be stopped; this
+    // runtime guard catches an incomplete state migration instead of treating
+    // the new namespace as an empty channel.
+    const legacyLedger = await this.primaryGet(this.legacyKey(channelId, 'ledger'));
+    const legacyLease = await this.primaryGet(this.legacyKey(channelId, 'lease'));
+    const legacyFence = await this.primaryGet(this.legacyKey(channelId, 'fence'));
+    if (legacyLedger !== null || legacyLease !== null || legacyFence !== null) {
+      throw new RedisKeyspaceMigrationRequiredError(channelId);
+    }
   }
 
   async get(channelId: string): Promise<ChannelLedgerEntry | null> {
-    const raw = await this.client.get(this.ledgerKey(channelId));
+    this.assertChannelId(channelId);
+    await this.assertClusterCutover(channelId);
+    const raw = await this.primaryGet(this.ledgerKey(channelId));
     if (raw === null) return null;
     return deserializeChannelLedgerEntry(JSON.parse(raw) as SerializedEntry);
   }
 
-  async set(channelId: string, entry: ChannelLedgerEntry): Promise<void> {
-    // The lease lives in its own key here; never persist a stale inline copy.
-    const serialized = serializeChannelLedgerEntry({ ...entry, lease: undefined });
-    await this.client.set(this.ledgerKey(channelId), JSON.stringify(serialized));
-  }
-
-  async delete(channelId: string): Promise<void> {
-    this.leaseTokens.delete(channelId);
-    await this.client.del(this.ledgerKey(channelId), this.leaseKey(channelId));
-  }
-
-  async tryAcquireLease(channelId: string, ttlMs: number): Promise<boolean> {
-    const token = randomUUID();
-    const result = await this.client.set(
+  private async writeIfOwned(
+    channelId: string,
+    entry: ChannelLedgerEntry,
+    lease: ChannelLease,
+  ): Promise<void> {
+    const serialized = serializeChannelLedgerEntry(entry);
+    const result = await this.client.eval(
+      SET_IF_LEASE_MATCHES_LUA,
+      2,
       this.leaseKey(channelId),
-      token,
-      'PX',
-      Math.max(1, Math.floor(ttlMs)),
-      'NX',
+      this.ledgerKey(channelId),
+      leaseIdentity(lease),
+      JSON.stringify(serialized),
     );
-    if (result !== 'OK') return false;
-    this.leaseTokens.set(channelId, token);
-    return true;
+    if (!mutationSucceeded(result)) throw new ChannelLeaseLostError(channelId);
   }
 
-  async releaseLease(channelId: string): Promise<void> {
-    const token = this.leaseTokens.get(channelId);
-    if (token === undefined) return; // not held by this instance — no-op
-    this.leaseTokens.delete(channelId);
-    await this.client.eval(RELEASE_IF_TOKEN_MATCHES_LUA, 1, this.leaseKey(channelId), token);
+  async set(channelId: string, entry: ChannelLedgerEntry, lease: ChannelLease): Promise<void> {
+    this.assertChannelId(channelId);
+    await withChannelLock(channelId, () => this.writeIfOwned(channelId, entry, lease));
+  }
+
+  async update(
+    channelId: string,
+    lease: ChannelLease,
+    updater: ChannelLedgerUpdater,
+  ): Promise<ChannelLedgerEntry> {
+    this.assertChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const next = updater(await this.get(channelId));
+      await this.writeIfOwned(channelId, next, lease);
+      return next;
+    });
+  }
+
+  async delete(channelId: string, lease: ChannelLease): Promise<void> {
+    this.assertChannelId(channelId);
+    await withChannelLock(channelId, async () => {
+      const result = await this.client.eval(
+        DELETE_IF_LEASE_MATCHES_LUA,
+        2,
+        this.leaseKey(channelId),
+        this.ledgerKey(channelId),
+        leaseIdentity(lease),
+      );
+      if (!mutationSucceeded(result)) throw new ChannelLeaseLostError(channelId);
+    });
+  }
+
+  async tryAcquireLease(channelId: string, ttlMs: number): Promise<ChannelLease | null> {
+    this.assertChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      await this.assertClusterCutover(channelId);
+      const ownerToken = randomUUID();
+      const ttl = normalizeLeaseTtlMs(ttlMs);
+      const result = await this.client.eval(
+        ACQUIRE_FENCED_LEASE_LUA,
+        2,
+        this.leaseKey(channelId),
+        this.fenceKey(channelId),
+        ownerToken,
+        ttl,
+      );
+      if (result === null || result === false || result === 0 || result === '0') return null;
+      const fence = String(result);
+      if (!/^[1-9][0-9]*$/.test(fence)) {
+        throw new Error(`Redis returned invalid channel fence: ${fence}`);
+      }
+      return {
+        ownerToken,
+        fence,
+        heldUntilUnixMs: Date.now() + ttl,
+      };
+    });
+  }
+
+  async releaseLease(channelId: string, lease: ChannelLease): Promise<boolean> {
+    this.assertChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const result = await this.client.eval(
+        RELEASE_IF_LEASE_MATCHES_LUA,
+        1,
+        this.leaseKey(channelId),
+        leaseIdentity(lease),
+      );
+      return mutationSucceeded(result);
+    });
+  }
+
+  async renewLease(
+    channelId: string,
+    lease: ChannelLease,
+    ttlMs: number,
+  ): Promise<ChannelLease> {
+    this.assertChannelId(channelId);
+    return withChannelLock(channelId, async () => {
+      const ttl = normalizeLeaseTtlMs(ttlMs);
+      const result = await this.client.eval(
+        RENEW_IF_LEASE_MATCHES_LUA,
+        1,
+        this.leaseKey(channelId),
+        leaseIdentity(lease),
+        ttl,
+      );
+      if (!mutationSucceeded(result)) throw new ChannelLeaseLostError(channelId);
+      return { ...lease, heldUntilUnixMs: Date.now() + ttl };
+    });
   }
 }

--- a/src/tab/seller/types.ts
+++ b/src/tab/seller/types.ts
@@ -16,12 +16,10 @@ import type {
 import type { ChannelLedger } from './channel-ledger';
 
 /**
- * Persistent store for the seller's per-tab voucher state. The middleware
- * writes the latest accepted voucher after every chunk so a process crash
- * loses at most the last in-flight voucher's worth of revenue. Pluggable to
- * match `batch-settlement/store`'s ChannelStore pattern.
+ * Legacy voucher-only persistence surface.
+ * @deprecated Superseded by fenced ChannelLedger, which also durably accounts
+ * delivered cumulative service before each send.
  */
-/** @deprecated Superseded by ChannelLedger (channel-ledger.ts), which also persists deliveredCumulative. */
 export interface VoucherStore {
   get(channelId: string): Promise<SignedVoucher | null>;
   set(channelId: string, voucher: SignedVoucher): Promise<void>;
@@ -52,10 +50,10 @@ export interface SellerTab {
    */
   deliveredCumulative(): HumanAmount;
   /**
-   * Add `incrementAtomic` (this request's delivered amount, atomic) to the
-   * channel's durable lifetime delivered total, under a per-channel lock.
-   * Monotonic — a non-positive increment is a no-op. Called by the meter once
-   * per request on the terminal path (end / cap-reject / disconnect).
+   * Write-ahead reserve `incrementAtomic` in the channel's durable delivered
+   * total before the corresponding chunk may be sent. Monotonic; a
+   * non-positive increment is a no-op. Conservative ambiguity (persisted but
+   * process dies before send) is safe; service may never precede accounting.
    */
   recordDelivered(incrementAtomic: AtomicAmount): Promise<void>;
 }
@@ -74,11 +72,32 @@ export interface TabMiddlewareOptions {
    * Durable per-channel state (latest voucher + delivered cumulative).
    * Default: in-memory (loses state on restart). Pass a FileChannelLedger or
    * your own ChannelLedger for restart-safe revenue + resumeTab support.
+   * Production safety modes reject adapters whose declared capabilities do
+   * not match the deployment topology or whose historical channel case
+   * aliases have not been migrated; configured store errors always propagate
+   * and never fall back to memory.
    */
   ledger?: ChannelLedger;
   /**
+   * Ledger safety contract. Required explicitly unless `NODE_ENV` is exactly
+   * `test` or `development`, where it defaults to `development`. An unset or
+   * misspelled deployment environment never silently enables memory/File
+   * state in production.
+   *
+   * - development: permits the in-memory adapter for local/test use.
+   * - production-single-instance: requires restart-safe durable state and a
+   *   canonical channel-ID cutover acknowledgement.
+   * - production-multi-instance: additionally requires cross-process atomic
+   *   fencing (for example RedisChannelLedger).
+   */
+  ledgerSafetyMode?:
+    | 'development'
+    | 'production-single-instance'
+    | 'production-multi-instance';
+  /**
    * Max single-stream duration before a crashed holder's lease auto-expires.
-   * Default 300000 (5 min).
+   * Must be an integer from 3 through 2147483647 milliseconds. Default
+   * 300000 (5 min). Live middleware renews it every third of this interval.
    */
   leaseTtlMs?: number;
   /**


### PR DESCRIPTION
## What changed

- replaces boolean stream ownership with owner-token plus monotonic-fence leases and conditions every seller-ledger mutation, renewal, and release on that exact generation
- makes SSE delivery accounting write-ahead and enforces the signed cumulative cap atomically, including concurrent meters and crash/takeover cases
- adds fail-closed production topology/capability gates, canonical channel-ID cutover protection, Redis primary reads and Lua fencing, and restart-safe File configuration
- revalidates durable voucher and reservation state after lease acquisition and contains disconnect/heartbeat failures
- updates canonical seller examples, proof scripts, README, reference, and migration guidance

## Why

The seller is the only party that can observe delivered API service. The prior in-memory default and unfenced writes could forget delivered-but-uncrystallized service after restart or let a stale process overwrite a takeover owner, re-granting already-used signed allowance.

## Impact

Production sellers must explicitly choose a durable ledger safety mode and acknowledge the documented legacy writer/channel-key cutovers. Memory remains available only for exact test/development use. Custom adapters must implement the new capability and fenced lease contract.

This PR is source/test ready only. Package publication, consumer deployment, and real restart/multi-instance acceptance remain separate, unproven states tracked in DEX-70.

## Validation

- full Vitest suite: 68/68 files, 630/630 tests
- TypeScript typecheck
- ESM/CJS build and DTS generation
- metered-inference, push-per-send, and live-chain relay examples compiled against the built package
- both real proof scripts syntax-checked and fail-fast configuration-smoked before credential/RPC/signing paths
- independent exact-diff P0/P1 review: clear
- `git diff --check`
