### PR TITLE
chore(release): 6.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.3] - 2026-08-17
+
 ### Added
 
 - Seller-owned delivery accounting is now restart- and takeover-safe. Every

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.2",
+  "version": "6.0.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexterai/x402",
-      "version": "6.0.0-rc.2",
+      "version": "6.0.0-rc.3",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.2",
+  "version": "6.0.0-rc.3",
   "description": "Full-stack x402 SDK - add paid API monetization to any endpoint. Express middleware, React hooks, Access Pass, dynamic pricing. Solana, Base, Polygon, Arbitrum, Optimism, Avalanche, World Chain, Monad, Robinhood Chain, SKALE.",
   "author": "Dexter",
   "license": "MIT",
@@ -61,6 +61,7 @@
     "dist",
     "README.md",
     "REFERENCE.md",
+    "CHANGELOG.md",
     "LICENSE",
     "assets/*.svg"
   ],


### PR DESCRIPTION
## Summary

- release the merged DEX-70 seller-durability work as `@dexterai/x402@6.0.0-rc.3`
- move the current changelog entries under the rc.3 release heading
- include `CHANGELOG.md` in the npm artifact so the mandatory seller-ledger and Redis migration links work for installed/offline consumers

## Verification

- `npm run typecheck`
- `npm test` — 68 files, 630 tests
- `npm run build`
- `git diff --check`
- clean tarball install with all 10 public entrypoints loaded through both ESM and CommonJS
- runtime seller-ledger smoke: restart persistence, canonical-ID rejection, stale-fence rejection, Redis/File capability declarations, and production fail-closed construction
- independent artifact review CLEAR on SHA-256 `fce38132396bd4bda5b8de69e2c7c8d40dd3f7b5efb923efc3ecdb6f143bb973`

## Release boundary

- npm version is currently unoccupied; `next` remains `6.0.0-rc.2`
- this PR does not publish the package, alter `latest`, or deploy any consumer
