### PR TITLE
chore: prepare x402 rc4 Vault rebind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.4] - 2026-08-17
+
+### Changed
+
+- Rebound the exact Vault peer and development dependency to
+  `@dexterai/vault@0.43.3-rc.1`. This is a package-metadata-only successor to
+  rc.3 so the canonical archive-mode Vault release resolves as one dependency
+  graph; x402 runtime source and declarations are unchanged.
+
 ## [6.0.0-rc.3] - 2026-08-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.3",
+  "version": "6.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexterai/x402",
-      "version": "6.0.0-rc.3",
+      "version": "6.0.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",
@@ -22,7 +22,7 @@
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
-        "@dexterai/vault": "0.43.2",
+        "@dexterai/vault": "0.43.3-rc.1",
         "@types/aws-lambda": "^8.10.161",
         "@types/express": "^5.0.6",
         "@types/node": "^22.10.0",
@@ -39,7 +39,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dexterai/vault": "0.43.2",
+        "@dexterai/vault": "0.43.3-rc.1",
         "@solana/wallet-adapter-base": "^0.9.0",
         "react": "^18.0.0 || ^19.0.0",
         "stripe": "^20.0.0",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@dexterai/vault": {
-      "version": "0.43.2",
-      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.2.tgz",
-      "integrity": "sha512-RYzML634iIEzOCEaBQ5Rur/NsMprZns3+X/1FcrmtOP62aMFnpGKK2Rcp9ncBbvoo1B7wMVLtUvYYkD5w9U/7w==",
+      "version": "0.43.3-rc.1",
+      "resolved": "https://registry.npmjs.org/@dexterai/vault/-/vault-0.43.3-rc.1.tgz",
+      "integrity": "sha512-KBxgQf3pEuz+7fsmyjIlm7xYxa/h1d+2ULoG/EpzTHolxcEuLyPLv4Kz8nbzOTJK8ca7SggHeWIiio/ek3IOiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.3",
+  "version": "6.0.0-rc.4",
   "description": "Full-stack x402 SDK - add paid API monetization to any endpoint. Express middleware, React hooks, Access Pass, dynamic pricing. Solana, Base, Polygon, Arbitrum, Optimism, Avalanche, World Chain, Monad, Robinhood Chain, SKALE.",
   "author": "Dexter",
   "license": "MIT",
@@ -92,7 +92,7 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@dexterai/vault": "0.43.2",
+    "@dexterai/vault": "0.43.3-rc.1",
     "@types/aws-lambda": "^8.10.161",
     "@types/express": "^5.0.6",
     "@types/node": "^22.10.0",
@@ -106,7 +106,7 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "@dexterai/vault": "0.43.2",
+    "@dexterai/vault": "0.43.3-rc.1",
     "@solana/wallet-adapter-base": "^0.9.0",
     "react": "^18.0.0 || ^19.0.0",
     "stripe": "^20.0.0",


### PR DESCRIPTION
## Summary
- advance x402 to 6.0.0-rc.4
- pin the exact Vault peer and dev dependency to 0.43.3-rc.1
- preserve runtime source unchanged while restoring a single canonical Vault graph

## Verification
- npm run typecheck
- npm run build
- npm test (630 passed)
- clean-archive/tar/install and rc3 byte-parity gates run after merge before publication

Stable/latest tags remain unchanged; this prerelease is next-only.