### PR TITLE
fix: transport oversized Native Tab registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fresh Native Tab registration now preserves the complete sibling-session
+  account set and falls back from legacy serialization to the existing v0+ALT
+  transport when that exact register exceeds Solana's 1232-byte packet cap.
+
 ## [6.0.0-rc.4] - 2026-08-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0-rc.5] - 2026-08-17
+
 ### Fixed
 
 - Fresh Native Tab registration now preserves the complete sibling-session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.4",
+  "version": "6.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dexterai/x402",
-      "version": "6.0.0-rc.4",
+      "version": "6.0.0-rc.5",
       "license": "MIT",
       "dependencies": {
         "@dexterai/x402-ads-types": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexterai/x402",
-  "version": "6.0.0-rc.4",
+  "version": "6.0.0-rc.5",
   "description": "Full-stack x402 SDK - add paid API monetization to any endpoint. Express middleware, React hooks, Access Pass, dynamic pricing. Solana, Base, Polygon, Arbitrum, Optimism, Avalanche, World Chain, Monad, Robinhood Chain, SKALE.",
   "author": "Dexter",
   "license": "MIT",

--- a/src/tab/__tests__/authorize-session-live.test.ts
+++ b/src/tab/__tests__/authorize-session-live.test.ts
@@ -9,8 +9,9 @@
  * adapter must therefore:
  *
  *   1. read the target PDA before registering;
- *   2. NOT live (absent / cleared / expired)  → the bare legacy register,
- *      byte-identical to the pre-K-T4e path (937 B — legacy-safe, K-T4a);
+ *   2. NOT live (absent / cleared / expired)  → the same bare register
+ *      pair, legacy when it fits and reviewed v0+ALT when required siblings
+ *      push legacy serialization past the wire cap;
  *   3. LIVE + no acknowledgement             → throw LiveSessionExistsError
  *      carrying the on-chain evidence (never silently strand the tail);
  *   4. LIVE + onLiveSession:'replace'        → compose the ATOMIC same-tx
@@ -28,6 +29,7 @@ import {
   deriveSessionPda,
   fetchSessionAccount,
   fetchVaultSessionAccounts,
+  resolveVaultUsdcAta,
 } from '@dexterai/vault/session';
 import {
   sessionRegisterMessage,
@@ -60,6 +62,8 @@ import { sha256 } from '@noble/hashes/sha256';
 const VAULT = Keypair.generate().publicKey;
 const SWIG = Keypair.generate().publicKey;
 const SELLER = Keypair.generate().publicKey;
+const OTHER_SELLER = Keypair.generate().publicKey;
+const VAULT_USDC_ATA = Keypair.generate().publicKey;
 const FEE_PAYER = Keypair.generate();
 const NOW = Math.floor(Date.now() / 1000);
 
@@ -78,6 +82,7 @@ function sessionAccountData(args: {
   spent?: bigint;
   currentOutstanding?: bigint;
   crystallized?: bigint;
+  allowedCounterparty?: PublicKey;
 }): Buffer {
   const buf = Buffer.alloc(162);
   Buffer.from([74, 34, 65, 133, 96, 163, 80, 69]).copy(buf, 0); // discriminator
@@ -87,7 +92,7 @@ function sessionAccountData(args: {
   Buffer.from(args.sessionPubkey ?? new Uint8Array(32).fill(0xd1)).copy(buf, 42);
   buf.writeBigUInt64LE(2_000_000n, 74); // max_amount
   buf.writeBigInt64LE(BigInt(args.expiresAt ?? NOW + 3600), 82);
-  SELLER.toBuffer().copy(buf, 90);
+  (args.allowedCounterparty ?? SELLER).toBuffer().copy(buf, 90);
   buf.writeUInt32LE(7, 122); // nonce
   buf.writeBigUInt64LE(args.spent ?? 0n, 126);
   buf.writeBigUInt64LE(args.currentOutstanding ?? 0n, 134);
@@ -98,6 +103,7 @@ function sessionAccountData(args: {
 }
 
 const SESSION_PDA = deriveSessionPda(VAULT, SELLER)[0];
+const OTHER_SESSION_PDA = deriveSessionPda(VAULT, OTHER_SELLER)[0];
 
 /** Minimal Connection double: getAccountInfo from a map, getProgramAccounts
  *  returns every map entry that parses as a SessionAccount for VAULT, plus
@@ -138,6 +144,7 @@ function makeAdapter(
     fetchSession?: typeof fetchSessionAccount;
     fetchSessions?: typeof fetchVaultSessionAccounts;
     fetchPasskeyAuthorization?: typeof fetchPasskeyAuthorizationState;
+    resolveUsdcAta?: typeof resolveVaultUsdcAta;
   } = {},
 ) {
   return createSolanaVaultAdapter({
@@ -239,6 +246,87 @@ describe('authorizeSession — target NOT live (absent / cleared / expired)', ()
     expect(Buffer.from(tx.instructions[1].data).equals(Buffer.from(expected.data))).toBe(true);
     expect(tx.instructions[1].keys.map((k) => k.pubkey.toBase58()))
       .toEqual(expected.keys.map((k) => k.pubkey.toBase58()));
+  });
+
+  it('preserves an unrelated expired sibling and falls back to v0+ALT when legacy is 1253 B', async () => {
+    const accounts = new Map([
+      [OTHER_SESSION_PDA.toBase58(), sessionAccountData({
+        allowedCounterparty: OTHER_SELLER,
+        expiresAt: NOW - 10,
+        currentOutstanding: 0n,
+        crystallized: 50_000n,
+      })],
+    ]);
+    const conn = fakeConnection(accounts);
+    const captured: TransactionInstruction[][] = [];
+    const composeSend = vi.fn(async (ixs: TransactionInstruction[]) => {
+      captured.push(ixs);
+      return 'ComposeSig111';
+    });
+    const adapter = makeAdapter(conn, {
+      composeSend,
+      resolveUsdcAta: vi.fn(async () => VAULT_USDC_ATA),
+    });
+
+    const session = await adapter.authorizeSession(scopeFor(), { onLiveSession: 'replace' });
+
+    expect(conn.legacySends).toHaveLength(0);
+    expect(composeSend).toHaveBeenCalledTimes(1);
+    expect(captured[0]).toHaveLength(2);
+    expect(captured[0][0].programId.equals(SECP256R1_PROGRAM_ID)).toBe(true);
+    expect(captured[0][1].programId.equals(DEXTER_VAULT_PROGRAM_ID)).toBe(true);
+
+    // Reproduce the live failure exactly: funded ATA + one unrelated sibling
+    // makes the otherwise-valid legacy transaction 1253 B (> 1232 B).
+    const legacy = new Transaction().add(...captured[0]);
+    legacy.feePayer = FEE_PAYER.publicKey;
+    legacy.recentBlockhash = 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k';
+    legacy.sign(FEE_PAYER);
+    expect(() => legacy.serialize()).toThrow('Transaction too large: 1253 > 1232');
+
+    // The fallback transports the exact registration instruction, including
+    // the expired-but-unswept sibling the program needs for atomic sweeping.
+    const message = sessionRegisterMessage({
+      programId: DEXTER_VAULT_PROGRAM_ID,
+      vaultPda: VAULT,
+      sessionPubkey: session.publicKey,
+      maxAmount: 1000000n,
+      maxRevolvingCapacity: 900000n,
+      expiresAt: BigInt(NOW + 1800),
+      allowedCounterparty: SELLER,
+      nonce: EXPECTED_NONCE,
+    });
+    const ceremony = canonicalCeremony(message);
+    const expected = buildRegisterSessionKeyInstruction({
+      vaultPda: VAULT,
+      sessionPubkey: session.publicKey,
+      maxAmount: 1000000n,
+      maxRevolvingCapacity: 900000n,
+      expiresAt: BigInt(NOW + 1800),
+      allowedCounterparty: SELLER,
+      nonce: EXPECTED_NONCE,
+      swigAddress: SWIG,
+      vaultUsdcAta: VAULT_USDC_ATA,
+      payer: FEE_PAYER.publicKey,
+      siblingSessionPdas: [OTHER_SESSION_PDA],
+      clientDataJSON: ceremony.clientDataJSON,
+      authenticatorData: ceremony.authenticatorData,
+    });
+    expect(Buffer.from(captured[0][1].data).equals(Buffer.from(expected.data))).toBe(true);
+    expect(captured[0][1].keys.map((k) => ({
+      pubkey: k.pubkey.toBase58(),
+      isSigner: k.isSigner,
+      isWritable: k.isWritable,
+    }))).toEqual(expected.keys.map((k) => ({
+      pubkey: k.pubkey.toBase58(),
+      isSigner: k.isSigner,
+      isWritable: k.isWritable,
+    })));
+    expect(captured[0][1].keys).toContainEqual(expect.objectContaining({
+      pubkey: OTHER_SESSION_PDA,
+      isSigner: false,
+      isWritable: true,
+    }));
   });
 });
 

--- a/src/tab/__tests__/compose-send.test.ts
+++ b/src/tab/__tests__/compose-send.test.ts
@@ -8,7 +8,8 @@
  * register] measures 1347 B legacy at ZERO siblings — past the 1232 B wire
  * cap; web3.js serialize() itself throws. With the per-vault statics AND
  * sibling session PDAs ALT-resident it lands at 1166–1174 B. The
- * register-only path stays legacy (937 B) and never routes here.
+ * register-only stays legacy while it fits, but reuses this transport when a
+ * complete sibling-account set pushes it past the packet cap.
  *
  * The MAINNET-HARDENING mirrored from dexter-api's proven K-T4b transport
  * (src/vault/revokeRegisterCompose.ts, live-tested 2026-07-06):

--- a/src/tab/adapters/solana/composeSend.ts
+++ b/src/tab/adapters/solana/composeSend.ts
@@ -10,8 +10,9 @@
  * table holding every non-signer account of the composed instructions
  * (vault, target session PDA, vaultUsdcAta, swig, swig wallet PDA, sysvar,
  * system program, sibling session PDAs) — 1166–1174 B on-chain-proven. The
- * register-only (not-live) path stays on the adapter's legacy send (937 B)
- * and never routes here.
+ * register-only (not-live) path stays on the adapter's legacy send while it
+ * fits and reuses this transport when required sibling accounts push it past
+ * the packet cap.
  *
  * SELF-PAYING vs SPONSORED: this is the buyer-side twin of dexter-api's
  * sponsor-owned K-T4b transport (dexter-api src/vault/revokeRegisterCompose.ts,

--- a/src/tab/adapters/solana/index.ts
+++ b/src/tab/adapters/solana/index.ts
@@ -631,8 +631,9 @@ class SolanaVaultAdapter implements VaultAdapter {
    * pre-guard program silently overwrote it — stranding the old session's
    * unsettled tail). So the adapter reads the PDA FIRST:
    *
-   *  - NOT live (absent / cleared / expired) → the bare legacy register,
-   *    exactly the pre-K-T4e bytes (937 B — legacy-size safe, K-T4a);
+   *  - NOT live (absent / cleared / expired) → the same bare register
+   *    instruction pair, legacy when it fits or v0+ALT when the complete
+   *    sibling-account set pushes the legacy wire past 1232 B;
    *  - LIVE + default policy → LiveSessionExistsError (stranding guard;
    *    thrown BEFORE any passkey ceremony is burned);
    *  - LIVE + onLiveSession:'replace' → ONE atomic transaction
@@ -794,9 +795,12 @@ class SolanaVaultAdapter implements VaultAdapter {
   }
 
   /**
-   * The NOT-live path: the bare [secp256r1, register_session_key] legacy
-   * transaction — byte-identical to the pre-K-T4e adapter (937 B, fits
-   * legacy comfortably; K-T4a proved only the revoke-composed tx overflows).
+   * The NOT-live path: the bare [secp256r1, register_session_key] instruction
+   * pair. It stays on the byte-identical legacy transport while it fits; if
+   * the complete sibling-account set makes legacy serialization exceed
+   * Solana's 1232-byte wire cap, the exact same pair uses the reviewed v0+ALT
+   * transport. Siblings may include expired-but-unswept sessions required by
+   * the on-chain admission/sweep contract and must never be dropped for size.
    */
   private async sendBareRegister(
     scope: SessionScope,
@@ -857,7 +861,32 @@ class SolanaVaultAdapter implements VaultAdapter {
     tx.recentBlockhash = blockhash;
     tx.sign(this.feePayer);
 
-    const sig = await this.connection.sendRawTransaction(tx.serialize(), {
+    let raw: Uint8Array;
+    try {
+      raw = tx.serialize();
+    } catch (err) {
+      // web3.js enforces Solana's 1232-byte packet cap at legacy
+      // serialization. Only that exact local size failure changes transport;
+      // every other signing/serialization fault remains fail-closed.
+      if (!/^Transaction too large: \d+ > 1232$/i.test(String((err as Error)?.message ?? err))) {
+        throw err;
+      }
+
+      const transport = this.seams.composeSend
+        ? { send: this.seams.composeSend, deactivateAlt: async () => {} }
+        : createSelfPayingComposeSend(this.connection, this.feePayer, {
+            commitment: this.confirmOptions.commitment,
+          });
+      try {
+        await transport.send([precompileIx, registerIx]);
+      } finally {
+        // Cleanup never gates (or fails) the registration that already landed.
+        void transport.deactivateAlt();
+      }
+      return;
+    }
+
+    const sig = await this.connection.sendRawTransaction(raw, {
       skipPreflight: false,
       preflightCommitment: this.confirmOptions.preflightCommitment ?? this.confirmOptions.commitment,
     });


### PR DESCRIPTION
## Summary

- preserve the exact fresh-session registration ceremony and complete sibling-session account set
- keep the legacy transaction path when it fits
- fall back only on the exact 1232-byte legacy serialization overflow to the existing reviewed v0+ALT transport
- advance the next-only prerelease to `6.0.0-rc.5`

## Root cause

A funded Vault with one unrelated expired-but-unswept sibling produced a valid 1253-byte legacy registration. The sibling is required for the program's aggregate admission and atomic expiry sweep, so dropping it or splitting the operation would be unsafe.

## Verification

- focused transport/authorization suite: 17 passed
- full SDK suite: 631 passed
- `npm run typecheck`
- `npm run build`
- exact regression reproduces `Transaction too large: 1253 > 1232` and proves the unchanged sibling remains writable
- clean-archive, deterministic pack, packed-install/import, registry integrity, and next-tag gates run from the merge commit before publication

Stable `latest` remains unchanged.